### PR TITLE
Run tests on github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+on: [push]
+name: "Tests and validation"
+
+jobs:
+  python-tests:
+    name: Python unit and integration tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          miniforge-version: latest
+      - name: Install narupa dependancies
+        run: conda install mpi4py openmm
+      - name: Install tests dependancies
+        run: python -m pip install -r python-libraries/requirements.test
+      - name: Compile
+        run: ./compile.sh --no-dotnet
+      - name: Parallel tests
+        run: python -m pytest --cov narupa python-libraries -n auto -m 'not serial'
+      - name: Serial tests
+        run: python -m pytest --cov narupa python-libraries -n auto -m 'serial'
+  csharp-tests:
+    name: C# unit and integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '2.1.x'
+      - name: Compile
+        run: ./compile.sh --no-python
+      - name: Tests
+        run: cd ./csharp-libraries && dotnet test


### PR DESCRIPTION
The python and dotnet tests run as github CI workflows. This means there
is a minimum amount of CI going on the github repository.

Note: not all the gitlab CI pipeline is ported yet! The conda packages
are neither built, tested, not published. The minimum version of the
dependencies is not tested. The python types are not validated.

See #2 