### PR TITLE
Solve some spurious tests in CI

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          python-version: 3.11
       - name: Set environment variables
         run: |
           echo NARUPA_BUILD_VERSION="0.1.$(git rev-list --count HEAD)" >> "$GITHUB_ENV"
@@ -69,7 +68,6 @@ jobs:
         with:
           auto-update-conda: true
           miniforge-version: latest
-          python-version: 3.11
       - name: Retrieve conda packages
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Some CI tests for the conda packages were failing because of a mistake regarding serial tests.