### PR TITLE
Clear state on simulation switch in omni

### DIFF
--- a/python-libraries/nanover-core/src/nanover/core/nanover_server.py
+++ b/python-libraries/nanover-core/src/nanover/core/nanover_server.py
@@ -105,6 +105,12 @@ class NanoverServer(GrpcServer):
             release = set()
         self._state_service.update_locks(access_token, acquire, release)
 
+    def clear_locks(self):
+        """
+        Forces the release all locks on all keys in the shared key/value store.
+        """
+        self._state_service.clear_locks()
+
     def _setup_command_service(self):
         self._command_service = CommandService()
         self.add_service(self._command_service)

--- a/python-libraries/nanover-core/src/nanover/state/state_dictionary.py
+++ b/python-libraries/nanover-core/src/nanover/state/state_dictionary.py
@@ -111,6 +111,12 @@ class StateDictionary:
             for key, duration in acquire.items():
                 self._write_locks.lock_key(access_token, key, duration)
 
+    def clear_locks(self):
+        """
+        Release all locks on all keys.
+        """
+        self._write_locks.release_all_keys()
+
     def _can_token_access_keys(self, access_token, keys):
         """
         Return whether or not all keys are either unlocked or locked by the

--- a/python-libraries/nanover-core/src/nanover/state/state_service.py
+++ b/python-libraries/nanover-core/src/nanover/state/state_service.py
@@ -93,6 +93,12 @@ class StateService(StateServicer):
         """
         self.state_dictionary.update_locks(access_token, acquire, release)
 
+    def clear_locks(self):
+        """
+        Release all locks on all keys.
+        """
+        self.state_dictionary.clear_locks()
+
     def get_change_buffer(self) -> ContextManager[DictionaryChangeBuffer]:
         """
         Return a DictionaryChangeBuffer that tracks changes to this service's

--- a/python-libraries/nanover-core/src/nanover/utilities/key_lockable_map.py
+++ b/python-libraries/nanover-core/src/nanover/utilities/key_lockable_map.py
@@ -56,6 +56,11 @@ class KeyLockableMap:
                 raise ResourceLockedError
             self._remove_lock(key)
 
+    def release_all_keys(self):
+        with self._lock:
+            self._key_lock_owners.clear()
+            self._key_lock_timeouts.clear()
+
     def remove_owner(self, owner_id):
         with self._lock:
             locked_keys = {

--- a/python-libraries/nanover-omni/src/nanover/omni/omni.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/omni.py
@@ -159,6 +159,7 @@ class OmniRunner:
                 for key in state.keys()
                 if any(key.startswith(prefix) for prefix in CLEAR_PREFIXES)
             }
+        self.app_server.server.clear_locks()
         self.app_server.server.update_state(None, DictionaryChange(removals=removals))
 
     def _load_simulation_selections(self):

--- a/python-libraries/nanover-omni/tests/test_all.py
+++ b/python-libraries/nanover-omni/tests/test_all.py
@@ -160,9 +160,11 @@ def test_simulation_switch_clears_state(multi_sim_runner):
     key = "pytest"
 
     updates = {prefix + key: {} for prefix in CLEAR_PREFIXES}
+    locks = {key: 10 for key in updates}
 
     with make_client_connected_to_runner(multi_sim_runner) as client:
         client.attempt_update_multiplayer_state(DictionaryChange(updates=updates))
+        client.attempt_update_multiplayer_locks(locks)
 
     with make_client_connected_to_runner(multi_sim_runner) as client:
         client.subscribe_multiplayer()


### PR DESCRIPTION
Assumes that all avatars, play areas, interactions, and visualisations should be erased. This makes sense for demos in the general case at least.

- [x] Clear keys
- [x] Clear locks
- [x] Write tests