### PR TITLE
Rework iMD in ASE

### DIFF
--- a/python-libraries/nanover-ase/src/nanover/ase/converter.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/converter.py
@@ -118,6 +118,9 @@ def ase_to_frame_data(
         )
     if include_forces:
         data.particle_forces_system = ase_atoms.get_forces() * (EV_TO_KJMOL / ANG_TO_NM)
+        data.particle_forces_system -= ase_atoms.calc.get_property(
+            "interactive_forces", allow_calculation=False
+        ) * (EV_TO_KJMOL / ANG_TO_NM)
 
     return data
 
@@ -263,6 +266,11 @@ def add_ase_state_to_frame_data(frame_data: FrameData, ase_atoms: Atoms):
         raise AttributeError("No calculator in atoms, so energy cannot be computed")
     if energy is not None:
         frame_data.potential_energy = energy * EV_TO_KJMOL
+        # Subtract iMD energy from total potential energy to obtain system potential energy
+        frame_data.potential_energy -= (
+            ase_atoms.calc.get_property("interactive_energy", allow_calculation=False)
+            * EV_TO_KJMOL
+        )
     frame_data.kinetic_energy = ase_atoms.get_kinetic_energy() * EV_TO_KJMOL
 
 

--- a/python-libraries/nanover-ase/src/nanover/ase/converter.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/converter.py
@@ -120,7 +120,9 @@ def ase_to_frame_data(
     if include_forces:
         data.particle_forces_system = ase_atoms.get_forces() * (EV_TO_KJMOL / ANG_TO_NM)
         if isinstance(ase_atoms.calc, ImdCalculator):
-            data.particle_forces_system -= ase_atoms.calc.results["interactive_forces"] * (EV_TO_KJMOL / ANG_TO_NM)
+            data.particle_forces_system -= ase_atoms.calc.results[
+                "interactive_forces"
+            ] * (EV_TO_KJMOL / ANG_TO_NM)
 
     return data
 
@@ -269,8 +271,10 @@ def add_ase_state_to_frame_data(frame_data: FrameData, ase_atoms: Atoms):
         # Subtract iMD energy from total potential energy to obtain system potential energy
         if isinstance(ase_atoms.calc, ImdCalculator):
             frame_data.potential_energy -= (
-                    ase_atoms.calc.get_property("interactive_energy", allow_calculation=False)
-                    * EV_TO_KJMOL
+                ase_atoms.calc.get_property(
+                    "interactive_energy", allow_calculation=False
+                )
+                * EV_TO_KJMOL
             )
     frame_data.kinetic_energy = ase_atoms.get_kinetic_energy() * EV_TO_KJMOL
 

--- a/python-libraries/nanover-ase/src/nanover/ase/converter.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/converter.py
@@ -204,7 +204,7 @@ def add_ase_velocities_to_frame_data(data: FrameData, ase_atoms: Atoms):
     :param ase_atoms: ASE :class:`Atoms` to add particle positions to.
     """
     data.particle_velocities = ase_atoms.get_velocities() * (
-            ANG_TO_NM / ASE_TIME_UNIT_TO_PS
+        ANG_TO_NM / ASE_TIME_UNIT_TO_PS
     )
 
 
@@ -220,9 +220,9 @@ def add_ase_forces_to_frame_data(data: FrameData, ase_atoms: Atoms):
 
     data.particle_forces_system = ase_atoms.get_forces() * (EV_TO_KJMOL / ANG_TO_NM)
     if isinstance(ase_atoms.calc, ImdCalculator):
-        data.particle_forces_system -= ase_atoms.calc.results[
-                                           "interactive_forces"
-                                       ] * (EV_TO_KJMOL / ANG_TO_NM)
+        data.particle_forces_system -= ase_atoms.calc.results["interactive_forces"] * (
+            EV_TO_KJMOL / ANG_TO_NM
+        )
 
 
 def add_ase_box_vectors_to_frame_data(data: FrameData, ase_atoms: Atoms):

--- a/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
@@ -36,13 +36,13 @@ class ImdForceManager:
 
     def update_interactions(self):
         """
-        Update the iMD interaction energies and forces (in ASE units)
+        Update the iMD interaction energies and forces (in ASE units).
         """
         self._update_forces(self.atoms)
 
     def add_to_frame_data(self, frame_data: FrameData):
         """
-        Add the iMD forces and energy to the frame data
+        Add the iMD forces and energy to the frame data.
         """
         frame_data.user_energy = self.total_user_energy * converter.EV_TO_KJMOL
         user_sparse_indices, user_sparse_forces = get_sparse_forces(self.user_forces)
@@ -285,6 +285,22 @@ class ImdCalculator(Calculator):
             self.results["forces"] = forces + imd_forces
             self.results["interactive_energy"] = imd_energy
             self.results["interactive_forces"] = imd_forces
+
+    def update_interactions(self):
+        """
+        Update the iMD interaction energies and forces (in ASE units)
+        via the ImdForceManager.
+        """
+        assert self._imd_force_manager is not None
+        self._imd_force_manager.update_interactions()
+
+    def add_to_frame_data(self, frame_data: FrameData):
+        """
+        Add the iMD forces and energy to the frame data via the
+        ImdForceManager.
+        """
+        assert self._imd_force_manager is not None
+        self._imd_force_manager.add_to_frame_data(frame_data)
 
     def _calculate_imd(self, atoms):
         interactions = self.interactions

--- a/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
@@ -24,7 +24,7 @@ class ImdForceManager:
     an ASE simulation.
     """
 
-    def __init__(self, atoms, imd_state: ImdStateWrapper):
+    def __init__(self, imd_state: ImdStateWrapper, atoms: Atoms):
         self.atoms = atoms
         self.imd_state = imd_state
 
@@ -131,7 +131,7 @@ class ImdCalculator(Calculator):
     def __init__(
         self,
         imd_state: ImdStateWrapper,
-        imd_force_manager: ImdForceManager,
+        imd_force_manager: Optional[ImdForceManager] = None,
         calculator: Optional[Calculator] = None,
         atoms: Optional[Atoms] = None,
         dynamics: Optional[MolecularDynamics] = None,

--- a/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
@@ -10,10 +10,11 @@ from ase import Atoms, units  # type: ignore
 from ase.calculators.calculator import Calculator, all_changes
 from ase.md.md import MolecularDynamics
 from ase.md.velocitydistribution import _maxwellboltzmanndistribution
-from nanover.imd.imd_force import calculate_imd_force
+from nanover.imd.imd_force import calculate_imd_force, get_sparse_forces
 from nanover.imd.imd_state import ImdStateWrapper
 from nanover.imd.particle_interaction import ParticleInteraction
-from nanover.trajectory.frame_data import MissingDataError
+from nanover.openmm.imd import ImdForceManager
+from nanover.trajectory.frame_data import MissingDataError, FrameData
 
 from . import converter
 
@@ -44,6 +45,7 @@ class ImdCalculator(Calculator):
     def __init__(
         self,
         imd_state: ImdStateWrapper,
+        imd_force_manager: ImdForceManager,
         calculator: Optional[Calculator] = None,
         atoms: Optional[Atoms] = None,
         dynamics: Optional[MolecularDynamics] = None,
@@ -52,6 +54,7 @@ class ImdCalculator(Calculator):
     ):
         super().__init__(**kwargs)
         self._imd_state = imd_state
+        self._imd_force_manager = imd_force_manager
         self.atoms = atoms
         self._calculator = calculator
         self.implemented_properties = [
@@ -175,7 +178,8 @@ class ImdCalculator(Calculator):
             energy = self.calculator.results["energy"]
             forces = self.calculator.results["forces"]
 
-        imd_energy, imd_forces = self._calculate_imd(atoms)
+        imd_energy = self._imd_force_manager.total_user_energy
+        imd_forces = self._imd_force_manager.user_forces
         self.results["energy"] = energy + imd_energy
         self.results["forces"] = forces + imd_forces
         self.results["interactive_energy"] = imd_energy
@@ -251,6 +255,86 @@ def get_periodic_box_lengths(atoms: Atoms) -> Optional[np.ndarray]:
             "Atoms object has periodic unit cell that is not orthorhombic, which is not supported!"
         )
     return lengths
+
+
+class ImdForceManager:
+    """
+    A class that calculates and stores the iMD forces and energies for
+    an ASE simulation.
+    """
+
+    def __init__(self, atoms, imd_state: ImdStateWrapper):
+        self.atoms = atoms
+
+        self.imd_state = imd_state
+
+        self.total_user_energy = 0.0
+        self.user_forces: np.ndarray = np.zeros(self.atoms.positions.shape)
+
+    def update_interactions(self):
+        """
+        Update the iMD interaction energies and forces (in ASE units)
+        """
+        self._update_forces(self.atoms)
+
+    def add_to_frame_data(self, frame_data: FrameData):
+        """
+        Add the iMD forces and energy to the frame data
+        """
+        frame_data.user_energy = self.total_user_energy * converter.EV_TO_KJMOL
+        user_sparse_indices, user_sparse_forces = get_sparse_forces(self.user_forces)
+        frame_data.user_forces_sparse = user_sparse_forces * (
+            converter.EV_TO_KJMOL / converter.ANG_TO_NM
+        )
+        frame_data.user_forces_index = user_sparse_indices
+
+    def _update_forces(self, atoms):
+        """
+        Get the forces to apply from the iMD service and communicate them
+        """
+        # Get the current interactions from the iMD service (if any)
+        interactions = self.imd_state.active_interactions
+
+        # Not sure what the line below is here for? Comment out for now?
+        # self._reset_velocities(atoms, interactions, self._previous_interactions)
+
+        # convert positions to the one true unit of distance, nanometers.
+        positions = atoms.positions * converter.ANG_TO_NM
+        energy = 0.0
+        forces = np.zeros(positions.shape)
+        # If there are iMD interactions, calculate their forces and energies
+        if interactions:
+            energy, forces = self._calculate_imd(atoms, positions, interactions)
+
+        # Store the energy and forces
+        self.total_user_energy = energy
+        self.user_forces = forces
+
+        # update previous interactions for next step.
+        self._previous_interactions = dict(interactions)
+
+    def _calculate_imd(
+        self,
+        atoms,
+        positions: np.ndarray,
+        interactions: Dict[str, ParticleInteraction],
+    ):
+        # masses are in amu, which is fine.
+        masses = atoms.get_masses()
+
+        periodic_box_lengths = get_periodic_box_lengths(atoms)
+        energy_kjmol, forces_kjmol = calculate_imd_force(
+            positions,
+            masses,
+            interactions.values(),
+            periodic_box_lengths=periodic_box_lengths,
+        )
+        ev_per_kjmol = converter.KJMOL_TO_EV
+        # convert back to ASE units (eV and Angstroms).
+        energy = energy_kjmol * ev_per_kjmol
+        forces = forces_kjmol * ev_per_kjmol / converter.NM_TO_ANG
+
+        return energy, forces
 
 
 def _get_cancelled_interactions(

--- a/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
@@ -233,30 +233,6 @@ class ImdCalculator(Calculator):
         self._previous_interactions = {}
 
 
-def get_periodic_box_lengths(atoms: Atoms) -> Optional[np.ndarray]:
-    """
-    Gets the periodic box lengths of an orthorhombic box, in nm, from an ASE atoms collection, if it exists.
-
-    :param atoms: ASE atoms.
-    :return: Array of periodic box lengths if periodic boundaries are in use, ``None`` otherwise.
-    """
-    if not np.all(atoms.get_pbc()):
-        if np.any(atoms.get_pbc()):
-            raise NotImplementedError(
-                "Atoms object has periodic unit cell on only some dimensions, which is not "
-                "supported."
-            )
-        return None
-    lengths_angles = atoms.cell.cellpar()
-    lengths = np.array(lengths_angles[0:3])
-    angles = np.array(lengths_angles[3:])
-    if not np.allclose(angles, (90, 90, 90)):
-        raise NotImplementedError(
-            "Atoms object has periodic unit cell that is not orthorhombic, which is not supported!"
-        )
-    return lengths
-
-
 class ImdForceManager:
     """
     A class that calculates and stores the iMD forces and energies for
@@ -335,6 +311,30 @@ class ImdForceManager:
         forces = forces_kjmol * ev_per_kjmol / converter.NM_TO_ANG
 
         return energy, forces
+
+
+def get_periodic_box_lengths(atoms: Atoms) -> Optional[np.ndarray]:
+    """
+    Gets the periodic box lengths of an orthorhombic box, in nm, from an ASE atoms collection, if it exists.
+
+    :param atoms: ASE atoms.
+    :return: Array of periodic box lengths if periodic boundaries are in use, ``None`` otherwise.
+    """
+    if not np.all(atoms.get_pbc()):
+        if np.any(atoms.get_pbc()):
+            raise NotImplementedError(
+                "Atoms object has periodic unit cell on only some dimensions, which is not "
+                "supported."
+            )
+        return None
+    lengths_angles = atoms.cell.cellpar()
+    lengths = np.array(lengths_angles[0:3])
+    angles = np.array(lengths_angles[3:])
+    if not np.allclose(angles, (90, 90, 90)):
+        raise NotImplementedError(
+            "Atoms object has periodic unit cell that is not orthorhombic, which is not supported!"
+        )
+    return lengths
 
 
 def _get_cancelled_interactions(

--- a/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
@@ -302,33 +302,6 @@ class ImdCalculator(Calculator):
         assert self._imd_force_manager is not None
         self._imd_force_manager.add_to_frame_data(frame_data)
 
-    def _calculate_imd(self, atoms):
-        interactions = self.interactions
-
-        self._reset_velocities(atoms, interactions, self._previous_interactions)
-
-        # convert positions to the one true unit of distance, nanometers.
-        positions = atoms.positions * converter.ANG_TO_NM
-        # masses are in amu, which is fine.
-        masses = atoms.get_masses()
-
-        periodic_box_lengths = get_periodic_box_lengths(atoms)
-        energy_kjmol, forces_kjmol = calculate_imd_force(
-            positions,
-            masses,
-            interactions.values(),
-            periodic_box_lengths=periodic_box_lengths,
-        )
-        ev_per_kjmol = converter.KJMOL_TO_EV
-        # convert back to ASE units (eV and Angstroms).
-        energy = energy_kjmol * ev_per_kjmol
-        forces = forces_kjmol * ev_per_kjmol / converter.NM_TO_ANG
-
-        # update previous interactions for next step.
-        self._previous_interactions = dict(interactions)
-
-        return energy, forces
-
     def _reset_velocities(self, atoms, interactions, previous_interactions):
         cancelled_interactions = _get_cancelled_interactions(
             interactions, previous_interactions

--- a/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
@@ -278,7 +278,9 @@ class ImdCalculator(Calculator):
                 self._reset_velocities(
                     atoms, self.interactions, self._previous_interactions
                 )
-                self._previous_interactions = self._imd_force_manager._previous_interactions
+                self._previous_interactions = (
+                    self._imd_force_manager._previous_interactions
+                )
                 self._imd_force_manager.call_reset_velocities = False
 
             # Retrieve iMD energy and forces and add to results

--- a/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
@@ -58,13 +58,8 @@ class ImdForceManager:
         # Get the current interactions from the iMD service (if any)
         interactions = self.imd_state.active_interactions
 
-        # Determine whether interactions are the same as previous, and if
-        # not call _reset_velocities in ImdCalculator
-        if interactions != self._previous_interactions:
-            self.call_reset_velocities = True
-
-        # Not sure what the line below is here for? Comment out for now?
-        # self._reset_velocities(atoms, interactions, self._previous_interactions)
+        # Call _reset_velocities in ImdCalculator
+        self.call_reset_velocities = True
 
         # convert positions to the one true unit of distance, nanometers.
         positions = atoms.positions * converter.ANG_TO_NM

--- a/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
@@ -264,7 +264,7 @@ class ImdCalculator(Calculator):
             energy = self.calculator.results["energy"]
             forces = self.calculator.results["forces"]
 
-        # Reset velocities (on first pass, if desired)
+        # Reset velocities (if desired)
         if self._imd_force_manager.call_reset_velocities:
             self._reset_velocities(atoms, self.interactions, self._previous_interactions)
             self._previous_interactions = self._imd_force_manager._previous_interactions

--- a/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/imd_calculator.py
@@ -266,7 +266,9 @@ class ImdCalculator(Calculator):
 
         # Reset velocities (if desired)
         if self._imd_force_manager.call_reset_velocities:
-            self._reset_velocities(atoms, self.interactions, self._previous_interactions)
+            self._reset_velocities(
+                atoms, self.interactions, self._previous_interactions
+            )
             self._previous_interactions = self._imd_force_manager._previous_interactions
             self._imd_force_manager.call_reset_velocities = False
 

--- a/python-libraries/nanover-ase/tests/test_imd_calculator.py
+++ b/python-libraries/nanover-ase/tests/test_imd_calculator.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from ase.calculators.lj import LennardJones
 from nanover.ase import converter
-from nanover.ase.imd_calculator import ImdCalculator, get_periodic_box_lengths
+from nanover.ase.imd_calculator import ImdCalculator, ImdForceManager, get_periodic_box_lengths
 from nanover.imd import ImdClient
 from nanover.imd.particle_interaction import ParticleInteraction
 from util import co_atoms, imd_server, client_interaction
@@ -29,7 +29,8 @@ def interact_c():
 def imd_calculator_co(imd_server):
     atoms = co_atoms()
     calculator = LennardJones()
-    imd_calculator = ImdCalculator(imd_server.imd_state, calculator, atoms)
+    imd_force_manager = ImdForceManager(atoms, imd_server.imd_state)
+    imd_calculator = ImdCalculator(imd_server.imd_state, imd_force_manager, calculator, atoms)
     yield imd_calculator, atoms, imd_server
 
 

--- a/python-libraries/nanover-ase/tests/test_imd_calculator.py
+++ b/python-libraries/nanover-ase/tests/test_imd_calculator.py
@@ -33,7 +33,7 @@ def interact_c():
 def imd_calculator_co(imd_server):
     atoms = co_atoms()
     calculator = LennardJones()
-    imd_force_manager = ImdForceManager(atoms, imd_server.imd_state)
+    imd_force_manager = ImdForceManager(imd_server.imd_state, atoms)
     imd_calculator = ImdCalculator(
         imd_server.imd_state, imd_force_manager, calculator, atoms
     )
@@ -43,7 +43,7 @@ def imd_calculator_co(imd_server):
 @pytest.fixture
 def imd_calculator_no_atoms(imd_server):
     calculator = LennardJones()
-    imd_calculator = ImdCalculator(imd_server.imd_state, calculator)
+    imd_calculator = ImdCalculator(imd_server.imd_state, calculator=calculator)
     yield imd_calculator
 
 

--- a/python-libraries/nanover-ase/tests/test_imd_calculator.py
+++ b/python-libraries/nanover-ase/tests/test_imd_calculator.py
@@ -133,8 +133,8 @@ def test_one_interaction(
         with client_interaction(imd_client, interact_c):
             time.sleep(0.1)
             assert len(imd_calculator.interactions) == 1
-            # Update interactions in force manager
-            imd_calculator._imd_force_manager.update_interactions()
+            # Update interactions
+            imd_calculator.update_interactions()
             imd_calculator.calculate(properties=properties)
             results = imd_calculator.results
 

--- a/python-libraries/nanover-ase/tests/test_imd_calculator.py
+++ b/python-libraries/nanover-ase/tests/test_imd_calculator.py
@@ -3,7 +3,11 @@ import pytest
 import numpy as np
 from ase.calculators.lj import LennardJones
 from nanover.ase import converter
-from nanover.ase.imd_calculator import ImdCalculator, ImdForceManager, get_periodic_box_lengths
+from nanover.ase.imd_calculator import (
+    ImdCalculator,
+    ImdForceManager,
+    get_periodic_box_lengths,
+)
 from nanover.imd import ImdClient
 from nanover.imd.particle_interaction import ParticleInteraction
 from util import co_atoms, imd_server, client_interaction
@@ -30,7 +34,9 @@ def imd_calculator_co(imd_server):
     atoms = co_atoms()
     calculator = LennardJones()
     imd_force_manager = ImdForceManager(atoms, imd_server.imd_state)
-    imd_calculator = ImdCalculator(imd_server.imd_state, imd_force_manager, calculator, atoms)
+    imd_calculator = ImdCalculator(
+        imd_server.imd_state, imd_force_manager, calculator, atoms
+    )
     yield imd_calculator, atoms, imd_server
 
 

--- a/python-libraries/nanover-ase/tests/test_imd_calculator.py
+++ b/python-libraries/nanover-ase/tests/test_imd_calculator.py
@@ -133,6 +133,8 @@ def test_one_interaction(
         with client_interaction(imd_client, interact_c):
             time.sleep(0.1)
             assert len(imd_calculator.interactions) == 1
+            # Update interactions in force manager
+            imd_calculator._imd_force_manager.update_interactions()
             imd_calculator.calculate(properties=properties)
             results = imd_calculator.results
 

--- a/python-libraries/nanover-ase/tests/test_imd_reset.py
+++ b/python-libraries/nanover-ase/tests/test_imd_reset.py
@@ -307,9 +307,11 @@ def test_reset_calculator(imd_calculator_berendsen_dynamics):
     calculator, atoms, dyn = imd_calculator
     atoms.calc = calculator
 
+    # TODO: not sure why we set this to none
     calculator.atoms = None
     calculator.calculate(atoms=atoms, system_changes=["numbers"])
     MaxwellBoltzmannDistribution(atoms, temperature_K=300)
+    calculator.atoms = atoms
 
     selection = [0, 1]
     selection = np.array(list(selection))

--- a/python-libraries/nanover-ase/tests/test_imd_reset.py
+++ b/python-libraries/nanover-ase/tests/test_imd_reset.py
@@ -317,13 +317,13 @@ def test_reset_calculator(imd_calculator_berendsen_dynamics):
         particles=selection,
         reset_velocities=True,
     )
-    # Add interaction to calculator and update force manager
+    # Add interaction to calculator and update interactions
     calculator._imd_state.insert_interaction("interaction.test", interaction)
-    calculator._imd_force_manager.update_interactions()
+    calculator.update_interactions()
     atoms.get_forces()
-    # Remove interaction from calculator and update force manager
+    # Remove interaction from calculator and update interactions
     calculator._imd_state.remove_interaction("interaction.test")
-    calculator._imd_force_manager.update_interactions()
+    calculator.update_interactions()
     atoms.get_forces()
 
     assert (

--- a/python-libraries/nanover-ase/tests/test_imd_reset.py
+++ b/python-libraries/nanover-ase/tests/test_imd_reset.py
@@ -159,7 +159,9 @@ def test_custom_temperature():
     atoms = fcc_atoms()
     calculator = LennardJones()
     imd_force_manager = ImdForceManager(atoms, server.imd_state)
-    imd_calculator = ImdCalculator(server.imd_state, imd_force_manager, calculator, atoms, reset_scale=0.1)
+    imd_calculator = ImdCalculator(
+        server.imd_state, imd_force_manager, calculator, atoms, reset_scale=0.1
+    )
     imd_calculator.temperature = 100
     assert pytest.approx(imd_calculator.reset_temperature) == 0.1 * 100
 

--- a/python-libraries/nanover-ase/tests/test_imd_reset.py
+++ b/python-libraries/nanover-ase/tests/test_imd_reset.py
@@ -70,7 +70,7 @@ def imd_calculator_berendsen_dynamics_context() -> (
     server = ImdServer(address=None, port=0)
     atoms = fcc_atoms()
     calculator = LennardJones()
-    imd_force_manager = ImdForceManager(atoms, server.imd_state)
+    imd_force_manager = ImdForceManager(server.imd_state, atoms)
     dynamics = NVTBerendsen(atoms, 1.0, TEST_TEMPERATURE, 1.0)
     imd_calculator = ImdCalculator(
         server.imd_state, imd_force_manager, calculator, atoms, dynamics=dynamics
@@ -96,7 +96,7 @@ def imd_calculator_langevin_dynamics():
     server = ImdServer(address=None, port=0)
     atoms = fcc_atoms()
     calculator = LennardJones()
-    imd_force_manager = ImdForceManager(atoms, server.imd_state)
+    imd_force_manager = ImdForceManager(server.imd_state, atoms)
     dynamics = Langevin(atoms, 1.0, friction=1.0, temperature_K=TEST_TEMPERATURE)
     imd_calculator = ImdCalculator(
         server.imd_state, imd_force_manager, calculator, atoms, dynamics=dynamics
@@ -158,7 +158,7 @@ def test_custom_temperature():
     server = ImdServer(address=None, port=0)
     atoms = fcc_atoms()
     calculator = LennardJones()
-    imd_force_manager = ImdForceManager(atoms, server.imd_state)
+    imd_force_manager = ImdForceManager(server.imd_state, atoms)
     imd_calculator = ImdCalculator(
         server.imd_state, imd_force_manager, calculator, atoms, reset_scale=0.1
     )

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -235,34 +235,5 @@ class ASESimulation:
         # Add the user forces and user energy to the frame (converting from ASE units
         # to NanoVer units)
         self.imd_force_manager.add_to_frame_data(frame_data)
-        if self.include_forces:
-            frame_data.particle_forces_system -= self.imd_force_manager.user_forces * (
-                EV_TO_KJMOL / ANG_TO_NM
-            )
-
-        # Add the user forces and user energy to the frame (converting from ASE units
-        # to NanoVer units) and subtract the user energy from the total potential
-        # energy to separately deliver the system potential energy (i.e. the PE without
-        # the iMD interaction) and the user energy (the PE of the iMD interaction)
-        # frame_data.user_energy = 0.0
-        # if self.atoms.calc.results["interactive_energy"]:
-        #     frame_data.user_energy = (
-        #         self.atoms.calc.results["interactive_energy"] * EV_TO_KJMOL
-        #     )
-        #     # Subtract the user energy from the potential energy
-        #     frame_data.potential_energy -= frame_data.user_energy
-        #     # If the particle forces are included in the frame data, subtract
-        #     # the user forces to deliver the internal forces of the system
-        #     # and iMD forces separately (i.e. subtract the iMD forces from the
-        #     # total forces)
-        #     if self.include_forces:
-        #         frame_data.particle_forces_system -= (
-        #             self.atoms.calc.results["interactive_forces"]
-        #         ) * (EV_TO_KJMOL / ANG_TO_NM)
-        # user_sparse_indices, user_sparse_forces = get_sparse_forces(
-        #     self.atoms.calc.results["interactive_forces"]
-        # )
-        # frame_data.user_forces_sparse = user_sparse_forces * (EV_TO_KJMOL / ANG_TO_NM)
-        # frame_data.user_forces_index = user_sparse_indices
 
         return frame_data

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -81,7 +81,6 @@ class ASESimulation:
         self.checkpoint: Optional[InitialState] = None
         self.initial_calc: Optional[Calculator] = None
 
-        self.imd_force_manager: Optional[ImdForceManager] = None
         self.imd_calculator: Optional[ImdCalculator] = None
 
         self.frame_index = 0
@@ -122,13 +121,10 @@ class ASESimulation:
         self.atoms.set_velocities(self.checkpoint.velocities)
         self.atoms.set_cell(self.checkpoint.cell)
 
-        # setup imd force manager
-        self.imd_force_manager = ImdForceManager(self.app_server.imd, self.atoms)
-
         # setup imd calculator
         self.imd_calculator = ImdCalculator(
             self.app_server.imd,
-            self.imd_force_manager,
+            ImdForceManager(self.app_server.imd, self.atoms),
             self.initial_calc,
             dynamics=self.dynamics,
         )

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -124,7 +124,7 @@ class ASESimulation:
         self.atoms.set_cell(self.checkpoint.cell)
 
         # setup imd force manager
-        self.imd_force_manager = ImdForceManager(self.atoms, self.app_server.imd)
+        self.imd_force_manager = ImdForceManager(self.app_server.imd, self.atoms)
 
         # setup calculator
         self.atoms.calc = ImdCalculator(

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -10,7 +10,6 @@ from ase.md.md import MolecularDynamics
 from nanover.app import NanoverImdApplication
 from nanover.ase.converter import (
     EV_TO_KJMOL,
-    ANG_TO_NM,
     ASE_TIME_UNIT_TO_PS,
     ase_atoms_to_frame_data,
 )
@@ -18,7 +17,6 @@ from nanover.ase.imd_calculator import ImdCalculator, ImdForceManager
 from nanover.ase.wall_constraint import VelocityWallConstraint
 from nanover.trajectory import FrameData
 from nanover.utilities.event import Event
-from nanover.imd.imd_force import get_sparse_forces
 
 
 @dataclass

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -232,6 +232,7 @@ class ASESimulation:
 
         # Add the user forces and user energy to the frame (converting from ASE units
         # to NanoVer units)
-        self.imd_force_manager.add_to_frame_data(frame_data)
+        if self.imd_force_manager is not None:
+            self.imd_force_manager.add_to_frame_data(frame_data)
 
         return frame_data

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -82,6 +82,7 @@ class ASESimulation:
         self.initial_calc: Optional[Calculator] = None
 
         self.imd_force_manager: Optional[ImdForceManager] = None
+        self.imd_calculator: Optional[ImdCalculator] = None
 
         self.frame_index = 0
         self.ase_atoms_to_frame_data = ase_atoms_to_frame_data
@@ -217,7 +218,7 @@ class ASESimulation:
         """
         Make a NanoVer FrameData corresponding to the current state of the simulation.
         """
-        assert self.atoms is not None
+        assert self.atoms is not None and self.imd_calculator is not None
 
         frame_data = self.ase_atoms_to_frame_data(
             self.atoms,
@@ -232,7 +233,6 @@ class ASESimulation:
 
         # Add the user forces and user energy to the frame (converting from ASE units
         # to NanoVer units)
-        if self.imd_force_manager is not None:
-            self.imd_force_manager.add_to_frame_data(frame_data)
+        self.imd_force_manager.add_to_frame_data(frame_data)
 
         return frame_data

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -125,13 +125,16 @@ class ASESimulation:
         # setup imd force manager
         self.imd_force_manager = ImdForceManager(self.app_server.imd, self.atoms)
 
-        # setup calculator
-        self.atoms.calc = ImdCalculator(
+        # setup imd calculator
+        self.imd_calculator = ImdCalculator(
             self.app_server.imd,
             self.imd_force_manager,
             self.initial_calc,
             dynamics=self.dynamics,
         )
+
+        # assign imd calculator to atoms
+        self.atoms.calc = self.imd_calculator
 
         # send the initial topology frame
         frame_data = self.make_topology_frame()
@@ -172,7 +175,7 @@ class ASESimulation:
         assert (
             self.dynamics is not None
             and self.app_server is not None
-            and self.imd_force_manager is not None
+            and self.imd_calculator is not None
         )
 
         # determine step count for next frame
@@ -185,7 +188,7 @@ class ASESimulation:
         self.dynamics.run(steps_to_next_frame)
 
         # update imd forces and energies
-        self.imd_force_manager.update_interactions()
+        self.imd_calculator.update_interactions()
 
         # generate the next frame
         frame_data = self.make_regular_frame()
@@ -218,7 +221,7 @@ class ASESimulation:
         """
         Make a NanoVer FrameData corresponding to the current state of the simulation.
         """
-        assert self.atoms is not None and self.imd_force_manager is not None
+        assert self.atoms is not None and self.imd_calculator is not None
 
         frame_data = self.ase_atoms_to_frame_data(
             self.atoms,
@@ -233,6 +236,6 @@ class ASESimulation:
 
         # Add the user forces and user energy to the frame (converting from ASE units
         # to NanoVer units)
-        self.imd_force_manager.add_to_frame_data(frame_data)
+        self.imd_calculator.add_to_frame_data(frame_data)
 
         return frame_data

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -218,7 +218,7 @@ class ASESimulation:
         """
         Make a NanoVer FrameData corresponding to the current state of the simulation.
         """
-        assert self.atoms is not None and self.imd_calculator is not None
+        assert self.atoms is not None and self.imd_force_manager is not None
 
         frame_data = self.ase_atoms_to_frame_data(
             self.atoms,

--- a/python-libraries/nanover-omni/tests/test_ase.py
+++ b/python-libraries/nanover-omni/tests/test_ase.py
@@ -127,7 +127,7 @@ def test_dynamics_interaction(example_ase):
             interaction_type="constant",
         ),
     )
-    for _ in range(30):
+    for _ in range(31):
         example_ase.advance_by_one_step()
 
     positions = example_ase.atoms.get_positions()
@@ -136,7 +136,8 @@ def test_dynamics_interaction(example_ase):
     # Applying a force of 1 kJ mol-1 nm-1 for
     # t = (0.5 fs * 5 simulation steps per advance * 30 advances) = 75 fs
     # using the velocity verlet algorithm should move the atom by 0.028125 nm
-    # using s = u*t + 0.5*a*(t^2). Allow for numerical error with pytest.approx:
+    # using s = u*t + 0.5*a*(t^2). 31 advances performed because there are no
+    # iMD forces on the first frame. Allow for numerical error with pytest.approx:
     assert z == pytest.approx(0.028125, abs=1e-8)
 
 


### PR DESCRIPTION
This PR reworks the ASE implementation of iMD so that we can use it to perform quantitative iMD in the same way as we do in OpenMM currently. To do this, I have:

- Added an iMD force manager (`ImdForceManager`) class akin to that in the OpenMM iMD file, which handles calculation of the iMD forces and energies, and adds them to the frame data
- Reworked the `calculate` function in the `ImdCalculator` class so that it no longer uses the "_calculate_imd(...)" function but instead retrieves the iMD forces and energies from the `ImdForceManager`
- Adjusted how the potential energies and system forces are added to the frame data to use this new functionality
- Fixed the existing tests in `test_imd_calculator` and `test_imd_reset`: These are only initial fixes, and while the tests all pass I think it would be worth thinking about whether we need to alter them in future (once we've settled on exactly how this new form of quantitative iMD should look)

In addition to the existing tests for the `ImdCalculator`, I have tested this new implementation locally using the same single atom system that I used to test OpenMM (a single argon atom with a constant force applied), and can confirm that this works as expected in terms of:
- Energies (potential, kinetic and user)
- Forces (system and user)
- Positions
- Velocities 

I have not yet written corresponding tests for the ImdForceManager: @Ragzouken should these tests go in a new file or be included in the same file that the iMD calculator is tested?