### PR TITLE
Calculate user work done in `ASESimulation`

### DIFF
--- a/python-libraries/nanover-core/src/nanover/imd/imd_force.py
+++ b/python-libraries/nanover-core/src/nanover/imd/imd_force.py
@@ -340,7 +340,7 @@ def get_sparse_forces(user_forces: npt.NDArray) -> Tuple[npt.NDArray, npt.NDArra
     return sparse_indices, sparse_forces
 
 
-def add_contribution_to_work(forces: npt.NDArray, positions: npt.NDArray):
+def calculate_contribution_to_work(forces: npt.NDArray, positions: npt.NDArray):
     r"""
     The expression for the work done on the system by the user is
 

--- a/python-libraries/nanover-core/src/nanover/imd/imd_force.py
+++ b/python-libraries/nanover-core/src/nanover/imd/imd_force.py
@@ -369,11 +369,14 @@ def add_contribution_to_work(forces: npt.NDArray, positions: npt.NDArray):
     i.e. kJ mol-1 nm-1)
     :param positions: Array of atomic positions of the atoms on which the user forces
     act (in NanoVer units, i.e. nm)
+    :return work_done_contribution: the contribution to the work done on the system (in NanoVer units of energy,
+    i.e. kJ mol-1)
     """
-    work_done_intermediate = 0.0
+    work_done_contribution = 0.0
     for atom in range(len(forces)):
-        work_done_intermediate += np.dot(np.transpose(forces[atom]), positions[atom])
-    return work_done_intermediate
+        work_done_contribution += np.dot(np.transpose(forces[atom]), positions[atom])
+
+    return work_done_contribution
 
 
 INTERACTION_METHOD_MAP: Dict[str, ForceCalculator] = {

--- a/python-libraries/nanover-core/src/nanover/imd/imd_force.py
+++ b/python-libraries/nanover-core/src/nanover/imd/imd_force.py
@@ -340,6 +340,42 @@ def get_sparse_forces(user_forces: npt.NDArray) -> Tuple[npt.NDArray, npt.NDArra
     return sparse_indices, sparse_forces
 
 
+def add_contribution_to_work(forces: npt.NDArray, positions: npt.NDArray):
+    r"""
+    The expression for the work done on the system by the user is
+
+    .. math::
+        W = \sum_{t = 1}^{n_{steps}} \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
+         \cdot (\mathbf{r}_{i}(t) - \mathbf{r}_{i}(t - 1)))
+
+    which can be rewritten as
+
+    .. math::
+        W = \sum_{t = 1}^{n_{steps}} \bigg(  \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
+         \cdot \mathbf{r}_{i}(t) \bigg)  - \bigg(  \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
+         \cdot \mathbf{r}_{i}(t - 1) \bigg)
+
+    where the contribution at each value of t is separated into an
+    previous-step contribution (t-1) and an on-step contribution (t). Doing so
+    enables calculation of the work done on-the-fly without having to save
+    the positions of the atoms at each time step that the user applies an
+    iMD force.
+
+    This function calculates the contribution to the work done on the system by the user
+    for a set of forces and positions, and add it to the work done on the system. Only
+    involves the atoms affected by the user interaction.
+
+    :param forces: Array of user forces acting on the system (in NanoVer units of force,
+    i.e. kJ mol-1 nm-1)
+    :param positions: Array of atomic positions of the atoms on which the user forces
+    act (in NanoVer units, i.e. nm)
+    """
+    work_done_intermediate = 0.0
+    for atom in range(len(forces)):
+        work_done_intermediate += np.dot(np.transpose(forces[atom]), positions[atom])
+    return work_done_intermediate
+
+
 INTERACTION_METHOD_MAP: Dict[str, ForceCalculator] = {
     "gaussian": calculate_gaussian_force,
     "spring": calculate_spring_force,

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -269,39 +269,3 @@ class ASESimulation:
         self.imd_calculator.add_to_frame_data(frame_data)
 
         return frame_data
-
-
-#    def add_contribution_to_work(self, forces: npt.NDArray, positions: npt.NDArray):
-#        r"""
-#        The expression for the work done on the system by the user is
-#
-#        .. math::
-#            W = \sum_{t = 1}^{n_{steps}} \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
-#             \cdot (\mathbf{r}_{i}(t) - \mathbf{r}_{i}(t - 1)))
-#
-#        which can be rewritten as
-#
-#        .. math::
-#            W = \sum_{t = 1}^{n_{steps}} \bigg(  \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
-#             \cdot \mathbf{r}_{i}(t) \bigg)  - \bigg(  \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
-#             \cdot \mathbf{r}_{i}(t - 1) \bigg)
-#
-#        where the contribution at each value of t is separated into an
-#        previous-step contribution (t-1) and an on-step contribution (t). Doing so
-#        enables calculation of the work done on-the-fly without having to save
-#        the positions of the atoms at each time step that the user applies an
-#        iMD force.
-#
-#        This function calculates the contribution to the work done on the system by the user
-#        for a set of forces and positions, and add it to the work done on the system. Only
-#        involves the atoms affected by the user interaction.
-#
-#        :param forces: Array of user forces acting on the system (in NanoVer units of force,
-#        i.e. kJ mol-1 nm-1)
-#        :param positions: Array of atomic positions of the atoms on which the user forces
-#        act (in NanoVer units, i.e. nm)
-#        """
-#        for atom in range(len(forces)):
-#            self._work_done_intermediate += np.dot(
-#                np.transpose(forces[atom]), positions[atom]
-#            )

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Optional, Any, Protocol
 
 import numpy as np
-import numpy.typing as npt
 from ase import Atoms
 from ase.calculators.calculator import Calculator
 from ase.md import MDLogger

--- a/python-libraries/nanover-omni/src/nanover/omni/openmm.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/openmm.py
@@ -242,34 +242,3 @@ class OpenMMSimulation:
         self.imd_force_manager.add_to_frame_data(frame_data)
 
         return frame_data
-
-
-#    def add_contribution_to_work(self, forces: npt.NDArray, positions: npt.NDArray):
-#        r"""
-#        The expression for the work done on the system by the user is
-#
-#        .. math::
-#            W = \sum_{t = 1}^{n_{steps}} \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
-#             \cdot (\mathbf{r}_{i}(t) - \mathbf{r}_{i}(t - 1)))
-#
-#        which can be rewritten as
-#
-#        .. math::
-#            W = \sum_{t = 1}^{n_{steps}} \bigg(  \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
-#             \cdot \mathbf{r}_{i}(t) \bigg)  - \bigg(  \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
-#             \cdot \mathbf{r}_{i}(t - 1) \bigg)
-#
-#        where the contribution at each value of t is separated into an
-#        previous-step contribution (t-1) and an on-step contribution (t). Doing so
-#        enables calculation of the work done on-the-fly without having to save
-#        the positions of the atoms at each time step that the user applies an
-#        iMD force.
-#
-#        This function calculates the contribution to the work done on the system by the user
-#        for a set of forces and positions, and add it to the work done on the system. Only
-#        involves the atoms affected by the user interaction.
-#        """
-#        for atom in range(len(forces)):
-#            self._work_done_intermediate += np.dot(
-#                np.transpose(forces[atom]), positions[atom]
-#            )

--- a/python-libraries/nanover-omni/src/nanover/omni/openmm.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/openmm.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Optional, Any
 
 import numpy as np
-import numpy.typing as npt
 
 from openmm.app import Simulation, StateDataReporter
 

--- a/python-libraries/nanover-omni/src/nanover/omni/openmm.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/openmm.py
@@ -16,6 +16,7 @@ from nanover.openmm.imd import (
     NON_IMD_FORCES_GROUP_MASK,
 )
 from nanover.trajectory.frame_data import Array2Dfloat
+from nanover.imd.imd_force import add_contribution_to_work
 
 
 class OpenMMSimulation:
@@ -166,7 +167,9 @@ class OpenMMSimulation:
         # Calculate on-step contribution to work
         if self.prev_imd_forces is not None:
             affected_atom_positions = positions[self.prev_imd_indices]
-            self.add_contribution_to_work(self.prev_imd_forces, affected_atom_positions)
+            self._work_done_intermediate += add_contribution_to_work(
+                self.prev_imd_forces, affected_atom_positions
+            )
 
         # update imd forces and energies
         self.imd_force_manager.update_interactions(self.simulation, positions)
@@ -179,10 +182,10 @@ class OpenMMSimulation:
         frame_data.user_work_done = self.work_done
 
         # Calculate previous-step contribution to work for the next time step
-        # (minus sign in positions accounts for subtraction of this contribution)
+        # (negative contribution, so subtract from the total work done)
         if frame_data.user_forces_sparse is not None:
-            affected_atom_positions = -positions[frame_data.user_forces_index]
-            self.add_contribution_to_work(
+            affected_atom_positions = positions[frame_data.user_forces_index]
+            self._work_done_intermediate -= add_contribution_to_work(
                 frame_data.user_forces_sparse, affected_atom_positions
             )
 
@@ -240,32 +243,33 @@ class OpenMMSimulation:
 
         return frame_data
 
-    def add_contribution_to_work(self, forces: npt.NDArray, positions: npt.NDArray):
-        r"""
-        The expression for the work done on the system by the user is
 
-        .. math::
-            W = \sum_{t = 1}^{n_{steps}} \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
-             \cdot (\mathbf{r}_{i}(t) - \mathbf{r}_{i}(t - 1)))
-
-        which can be rewritten as
-
-        .. math::
-            W = \sum_{t = 1}^{n_{steps}} \bigg(  \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
-             \cdot \mathbf{r}_{i}(t) \bigg)  - \bigg(  \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
-             \cdot \mathbf{r}_{i}(t - 1) \bigg)
-
-        where the contribution at each value of t is separated into an
-        previous-step contribution (t-1) and an on-step contribution (t). Doing so
-        enables calculation of the work done on-the-fly without having to save
-        the positions of the atoms at each time step that the user applies an
-        iMD force.
-
-        This function calculates the contribution to the work done on the system by the user
-        for a set of forces and positions, and add it to the work done on the system. Only
-        involves the atoms affected by the user interaction.
-        """
-        for atom in range(len(forces)):
-            self._work_done_intermediate += np.dot(
-                np.transpose(forces[atom]), positions[atom]
-            )
+#    def add_contribution_to_work(self, forces: npt.NDArray, positions: npt.NDArray):
+#        r"""
+#        The expression for the work done on the system by the user is
+#
+#        .. math::
+#            W = \sum_{t = 1}^{n_{steps}} \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
+#             \cdot (\mathbf{r}_{i}(t) - \mathbf{r}_{i}(t - 1)))
+#
+#        which can be rewritten as
+#
+#        .. math::
+#            W = \sum_{t = 1}^{n_{steps}} \bigg(  \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
+#             \cdot \mathbf{r}_{i}(t) \bigg)  - \bigg(  \sum_{i = 1}^{N} \mathbf{F}_{i}(t - 1)
+#             \cdot \mathbf{r}_{i}(t - 1) \bigg)
+#
+#        where the contribution at each value of t is separated into an
+#        previous-step contribution (t-1) and an on-step contribution (t). Doing so
+#        enables calculation of the work done on-the-fly without having to save
+#        the positions of the atoms at each time step that the user applies an
+#        iMD force.
+#
+#        This function calculates the contribution to the work done on the system by the user
+#        for a set of forces and positions, and add it to the work done on the system. Only
+#        involves the atoms affected by the user interaction.
+#        """
+#        for atom in range(len(forces)):
+#            self._work_done_intermediate += np.dot(
+#                np.transpose(forces[atom]), positions[atom]
+#            )

--- a/python-libraries/nanover-omni/tests/test_ase.py
+++ b/python-libraries/nanover-omni/tests/test_ase.py
@@ -352,7 +352,9 @@ def test_work_done_server(example_ase_app_sim_constant_force_interaction):
         sim.advance_to_next_report()
 
     # Check that 1.0025 ps have passed (and hence that force has been applied for 1 ps)
-    assert sim.dynamics.get_time() * ASE_TIME_UNIT_TO_PS == pytest.approx(1.0025, abs=10e-12)
+    assert sim.dynamics.get_time() * ASE_TIME_UNIT_TO_PS == pytest.approx(
+        1.0025, abs=10e-12
+    )
     assert sim.work_done == pytest.approx(20.0, abs=1e-6)
 
 

--- a/python-libraries/nanover-omni/tests/test_ase.py
+++ b/python-libraries/nanover-omni/tests/test_ase.py
@@ -50,7 +50,7 @@ def example_ase_app_sim_constant_force_interaction(example_ase_app_sim):
 
 @pytest.fixture
 def example_dynamics():
-    atoms = Atoms("Ar", positions=[(0, 0, 0)], cell=[2, 2, 2])
+    atoms = Atoms("Ar", positions=[(0, 0, 0)], masses=[40.0], cell=[2, 2, 2])
     atoms.calc = LennardJones()
     dynamics = VelocityVerlet(atoms, timestep=0.5 * ase_units.fs)
     yield dynamics
@@ -329,3 +329,46 @@ def test_imd_force_unit_conversion(example_ase_app_sim_constant_force_interactio
             assert particle_forces[f_i] == pytest.approx(
                 particle_forces_frame[f_i], rel=1e-7
             )
+
+
+def test_work_done_server(example_ase_app_sim_constant_force_interaction):
+    """
+    Test that the calculated user work done on a single atom system gives the
+    expected numerical result within the code.
+    """
+
+    # For a simulation with a frame interval of 5 simulation steps and a simulation
+    # step size of 0.5 fs, using a constant force to accelerate the atom at 1 nm ps-1
+    # (for Ar this is a force of 40 kJ mol-1 nm-1), after 401 steps the work done on
+    # an Argon atom should be 20.0 kJ mol-1 analytically. Allowing for numerical error,
+    # the expected value should be slightly greater than 20.0 kJ mol-1
+
+    app, sim = example_ase_app_sim_constant_force_interaction
+
+    print(sim.atoms.get_masses())
+
+    # Add step to account for zeroth (topology) frame where force is not applied
+    for _ in range(401):
+        sim.advance_to_next_report()
+
+    # Check that 1.0025 ps have passed (and hence that force has been applied for 1 ps)
+    assert sim.dynamics.get_time() * ASE_TIME_UNIT_TO_PS == pytest.approx(1.0025, abs=10e-12)
+    assert sim.work_done == pytest.approx(20.0, abs=1e-6)
+
+
+def test_work_done_frame(example_ase_app_sim_constant_force_interaction):
+    """
+    Test that the calculated user work done on a single atom system that appears
+    in the frame is equal to the user work done as calculated in the ASESimulation.
+    """
+    app, sim = example_ase_app_sim_constant_force_interaction
+
+    for _ in range(11):
+        sim.advance_to_next_report()
+
+    with NanoverImdClient.connect_to_single_server(
+        port=app.port, address="localhost"
+    ) as client:
+        client.subscribe_to_frames()
+        client.wait_until_first_frame()
+        assert client.current_frame.user_work_done == sim.work_done

--- a/python-libraries/nanover-omni/tests/test_ase.py
+++ b/python-libraries/nanover-omni/tests/test_ase.py
@@ -345,8 +345,6 @@ def test_work_done_server(example_ase_app_sim_constant_force_interaction):
 
     app, sim = example_ase_app_sim_constant_force_interaction
 
-    print(sim.atoms.get_masses())
-
     # Add step to account for zeroth (topology) frame where force is not applied
     for _ in range(401):
         sim.advance_to_next_report()


### PR DESCRIPTION
This PR adds the functionality to calculate the work done by the user on the molecular system to the ASESimulation class. It does so in the same way as implemented for OpenMM. As both `ASESimulation` and `OpenMMSimulation` classes need to calculate this quantity, the function `add_contribution_to_work` that was a function of the `OpenMMSimulation` class has now been moved to `imd_force.py`, and the calculation of work done in `OpenMMSimulation` has been refactored to reflect this.

So far, I have tested this PR locally using the single-atom system that I have been using to test previous PRs (consisting of a single Ar atom, to which a constant force is applied for a specified amount of time). This produces the same results as the OpenMM implementation, and the OpenMM implementation produces the same results as it did previously with the same system.

I have added corresponding tests to confirm that the ASE implementation works as expected. These tests take the same form as the existing tests that check the work done for OpenMM.