### PR TITLE
Fix docstring formatting

### DIFF
--- a/python-libraries/nanover-core/src/nanover/imd/imd_force.py
+++ b/python-libraries/nanover-core/src/nanover/imd/imd_force.py
@@ -366,11 +366,11 @@ def calculate_contribution_to_work(forces: npt.NDArray, positions: npt.NDArray):
     involves the atoms affected by the user interaction.
 
     :param forces: Array of user forces acting on the system (in NanoVer units of force,
-    i.e. kJ mol-1 nm-1)
+        i.e. kJ mol-1 nm-1)
     :param positions: Array of atomic positions of the atoms on which the user forces
-    act (in NanoVer units, i.e. nm)
+        act (in NanoVer units, i.e. nm)
     :return work_done_contribution: the contribution to the work done on the system (in NanoVer units of energy,
-    i.e. kJ mol-1)
+        i.e. kJ mol-1)
     """
     work_done_contribution = 0.0
     for atom in range(len(forces)):

--- a/python-libraries/nanover-jupyter/src/nanover/nglview/nglclient.py
+++ b/python-libraries/nanover-jupyter/src/nanover/nglview/nglclient.py
@@ -107,7 +107,7 @@ def frame_data_to_nglwidget(frame, **kwargs):
 
     :param frame: The FrameData object containing the data from the
         molecular simulation.
-    :param *kwargs: Additional keyword arguments passed to the
+    :param kwargs: Additional keyword arguments passed to the
         NGLWidget constructor.
     :return: An NGLView widget to visualise the molecular system
         described by the frame.

--- a/python-libraries/nanover-openmm/src/nanover/openmm/serializer.py
+++ b/python-libraries/nanover-openmm/src/nanover/openmm/serializer.py
@@ -24,7 +24,7 @@ optionally, an OpenMM serialized state. The resulting XML file looks like:
 
 The ``System``, ``Integrator`` and ``State`` tags are the roots of the serialized
 system, integrator and state, respectively. The ``pdbx`` tag can be replaced by a
- ``pdb`` one for backward compatibility.
+``pdb`` one for backward compatibility.
 
 This module provides a function :func:`serialize_simulation` that generates an
 XML file from an existing instance of :class:`openmm.app.Simulation`, and


### PR DESCRIPTION
Fix the following errors given by docs generator:

```
C:\Users\ragzo\Documents\REPOS\nanover-docs\nanover-server-py\python-libraries\nanover-core\src\nanover\imd\imd_force.py:docstring of nanover.imd.imd_force.calculate_contribution_to_work:25: WARNING: Field list ends without a blank line; unexpected unindent. [docutils]
C:\Users\ragzo\Documents\REPOS\nanover-docs\nanover-server-py\python-libraries\nanover-jupyter\src\nanover\nglview\nglclient.py:docstring of nanover.nglview.nglclient.frame_data_to_nglwidget:7: WARNING: Inline emphasis start-string without end-string. [docutils]
C:\Users\ragzo\Documents\REPOS\nanover-docs\nanover-server-py\python-libraries\nanover-openmm\src\nanover\openmm\serializer.py:docstring of nanover.openmm.serializer:26: ERROR: Unexpected indentation. [docutils]
```
