### PR TITLE
Improve nanover-omni tests

### DIFF
--- a/python-libraries/nanover-omni/src/nanover/omni/cli.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/cli.py
@@ -155,7 +155,7 @@ def main():
 
     with initialise_runner(arguments) as runner:
         if len(runner.simulations) > 0:
-            runner.next()
+            runner.load(0)
 
         if arguments.rich:
             try:

--- a/python-libraries/nanover-omni/tests/common.py
+++ b/python-libraries/nanover-omni/tests/common.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from pathlib import Path
-from nanover.app import NanoverImdApplication, NanoverImdClient
+from nanover.app import NanoverImdClient, NanoverApplicationServer, NanoverImdApplication
 from nanover.omni import OmniRunner
 
 EXAMPLES_PATH = Path(__file__).parent
@@ -30,12 +30,12 @@ def make_connected_client_from_runner(runner):
 
 
 @contextmanager
-def make_connected_client_from_app_server(app_server):
+def make_connected_client_from_app_server(app_server: NanoverApplicationServer):
     with NanoverImdClient.connect_to_single_server(port=app_server.port) as client:
         yield client
 
 
-def connect_and_retrieve_first_frame_from_app_server(app_server):
+def connect_and_retrieve_first_frame_from_app_server(app_server: NanoverApplicationServer):
     with make_connected_client_from_app_server(app_server) as client:
         client.subscribe_to_frames()
         return client.wait_until_first_frame()

--- a/python-libraries/nanover-omni/tests/common.py
+++ b/python-libraries/nanover-omni/tests/common.py
@@ -1,6 +1,10 @@
 from contextlib import contextmanager
 from pathlib import Path
-from nanover.app import NanoverImdClient, NanoverApplicationServer, NanoverImdApplication
+from nanover.app import (
+    NanoverImdClient,
+    NanoverApplicationServer,
+    NanoverImdApplication,
+)
 from nanover.omni import OmniRunner
 
 EXAMPLES_PATH = Path(__file__).parent
@@ -47,7 +51,9 @@ def make_connected_client_from_app_server(app_server: NanoverApplicationServer):
         yield client
 
 
-def connect_and_retrieve_first_frame_from_app_server(app_server: NanoverApplicationServer):
+def connect_and_retrieve_first_frame_from_app_server(
+    app_server: NanoverApplicationServer,
+):
     with make_connected_client_from_app_server(app_server) as client:
         client.subscribe_to_frames()
         return client.wait_until_first_frame()

--- a/python-libraries/nanover-omni/tests/common.py
+++ b/python-libraries/nanover-omni/tests/common.py
@@ -1,8 +1,7 @@
+from contextlib import contextmanager
 from pathlib import Path
-
-import pytest
-
-from nanover.app import NanoverImdApplication
+from nanover.app import NanoverImdApplication, NanoverImdClient
+from nanover.omni import OmniRunner
 
 EXAMPLES_PATH = Path(__file__).parent
 RECORDING_PATH_TRAJ = EXAMPLES_PATH / "nanotube-example-recording.traj"
@@ -10,7 +9,39 @@ RECORDING_PATH_STATE = EXAMPLES_PATH / "nanotube-example-recording.state"
 ARGON_XML_PATH = EXAMPLES_PATH / "argon_simulation.xml"
 
 
-@pytest.fixture
-def app_server():
+@contextmanager
+def make_loaded_sim(sim):
+    with make_app_server() as app_server:
+        sim.load()
+        sim.reset(app_server)
+        yield sim
+
+
+@contextmanager
+def make_runner(*simulations):
+    with OmniRunner.with_basic_server(*simulations, port=0) as runner:
+        yield runner
+
+
+@contextmanager
+def make_connected_client_from_runner(runner):
+    with make_connected_client_from_app_server(runner.app_server) as client:
+        yield client
+
+
+@contextmanager
+def make_connected_client_from_app_server(app_server):
+    with NanoverImdClient.connect_to_single_server(port=app_server.port) as client:
+        yield client
+
+
+def connect_and_retrieve_first_frame_from_app_server(app_server):
+    with make_connected_client_from_app_server(app_server) as client:
+        client.subscribe_to_frames()
+        return client.wait_until_first_frame()
+
+
+@contextmanager
+def make_app_server():
     with NanoverImdApplication.basic_server(port=0) as app_server:
         yield app_server

--- a/python-libraries/nanover-omni/tests/common.py
+++ b/python-libraries/nanover-omni/tests/common.py
@@ -18,6 +18,18 @@ def make_loaded_sim(sim):
 
 
 @contextmanager
+def make_loaded_sim_with_interactions(sim, *interactions):
+    with make_app_server() as app_server:
+        sim.load()
+        sim.reset(app_server)
+
+        for i, interaction in enumerate(interactions):
+            app_server.imd.insert_interaction(f"interaction.{i}", interaction)
+
+        yield app_server, sim
+
+
+@contextmanager
 def make_runner(*simulations):
     with OmniRunner.with_basic_server(*simulations, port=0) as runner:
         yield runner

--- a/python-libraries/nanover-omni/tests/openmm_simulation_utils.py
+++ b/python-libraries/nanover-omni/tests/openmm_simulation_utils.py
@@ -4,8 +4,6 @@ Fixtures and utilities for tests that requires OpenMM simulations.
 
 # Pylint does not recognize pytest fixtures, which causes some false warnings.
 # pylint: disable=unused-argument,redefined-outer-name
-import pytest
-from typing import Optional
 import numpy as np
 
 import openmm as mm
@@ -19,9 +17,6 @@ from openmm.unit import (
     femtosecond,
     nanometer,
 )  # pylint: disable=no-name-in-module
-
-from nanover.openmm import serializer
-import nanover.openmm.imd
 
 
 BASIC_SIMULATION_BOX_VECTORS = [[50, 0, 0], [0, 50, 0], [0, 0, 50]]
@@ -39,31 +34,6 @@ BASIC_SIMULATION_POSITIONS = [
     [-10.685, -0.537, 6.921],  # H
 ]
 ARGON_SIMULATION_POSITION = [[0.0, 0.0, 0.0]]
-
-
-class DoNothingReporter:
-    """
-    OpenMM reporter that does nothing.
-
-    The reporter does nothing but is valid. It is meant to populate the list of
-    reporters of an OpenMM simulation.
-    """
-
-    # The name of the method is part of the OpenMM API. It cannot be made to
-    # conform PEP8.
-    def describeNextReport(
-        self, simulation
-    ):  # pylint: disable=invalid-name,no-self-use
-        """
-        Activate the reporting every step, but collect no data.
-        """
-        return 1, False, False, False, False
-
-    def report(self, simulation, state):
-        """
-        Do not report anything.
-        """
-        pass
 
 
 def build_basic_system():
@@ -106,24 +76,15 @@ def build_basic_topology() -> app.Topology:
     return topology
 
 
-def build_basic_simulation(
-    imd_force: Optional[mm.CustomExternalForce] = None,
-) -> app.Simulation:
+def build_basic_simulation():
     """
     Setup a minimal OpenMM simulation with two methane molecules.
     """
-    # In ths function, we define matrices and we want to align the column.
-    # We disable the pylint warning about bad spacing for the scope of the
-    # function.
-    # pylint: disable=bad-whitespace
     periodic_box_vector = BASIC_SIMULATION_BOX_VECTORS
     positions = np.array(BASIC_SIMULATION_POSITIONS, dtype=np.float32)
 
     topology = build_basic_topology()
     system = build_basic_system()
-    if imd_force is not None:
-        nanover.openmm.imd.populate_imd_force(imd_force, system)
-        system.addForce(imd_force)
 
     force = mm.NonbondedForce()
     force.setNonbondedMethod(force.NoCutoff)
@@ -148,50 +109,6 @@ def build_basic_simulation(
     simulation.context.setPositions(positions * nanometer)
 
     return simulation
-
-
-@pytest.fixture
-def basic_system():
-    return build_basic_system()
-
-
-@pytest.fixture
-def basic_simulation():
-    return build_basic_simulation()
-
-
-@pytest.fixture
-def basic_simulation_with_imd_force():
-    imd_force = nanover.openmm.imd.create_imd_force()
-    return build_basic_simulation(imd_force), imd_force
-
-
-@pytest.fixture
-def serialized_simulation_path(basic_simulation, tmp_path):
-    """
-    Setup an XML serialized simulation as a temporary file.
-    """
-    serialized_simulation = serializer.serialize_simulation(
-        basic_simulation, save_state=True
-    )
-    xml_path = tmp_path / "system.xml"
-    with open(str(xml_path), "w") as outfile:
-        outfile.write(serialized_simulation)
-    return xml_path
-
-
-@pytest.fixture
-def basic_simulation_xml(basic_simulation):
-    """
-    Generate an XML serialized simulation from the basic test simulation.
-    """
-    xml_string = serializer.serialize_simulation(basic_simulation, save_state=True)
-    return xml_string
-
-
-@pytest.fixture
-def empty_imd_force():
-    return nanover.openmm.imd.create_imd_force()
 
 
 def assert_basic_simulation_topology(frame):
@@ -232,16 +149,11 @@ def build_single_atom_topology() -> app.Topology:
     return topology
 
 
-def build_single_atom_simulation(
-    imd_force: Optional[mm.CustomExternalForce] = None,
-) -> app.Simulation:
+def build_single_atom_simulation():
     periodic_box_vector = BASIC_SIMULATION_BOX_VECTORS
     positions = np.array(ARGON_SIMULATION_POSITION, dtype=np.float32)
     topology = build_single_atom_topology()
     system = build_single_atom_system()
-    if imd_force is not None:
-        nanover.openmm.imd.populate_imd_force(imd_force, system)
-        system.addForce(imd_force)
 
     # As we are only dealing with a single atom system, it is unnecessary to
     # add a non-bonded force.
@@ -256,47 +168,6 @@ def build_single_atom_simulation(
     simulation.context.setPositions(positions * nanometer)
 
     return simulation
-
-
-@pytest.fixture
-def single_atom_system():
-    return build_single_atom_system()
-
-
-@pytest.fixture
-def single_atom_simulation():
-    return build_single_atom_simulation()
-
-
-@pytest.fixture
-def single_atom_simulation_with_imd_force():
-    imd_force = nanover.openmm.imd.create_imd_force()
-    return build_single_atom_simulation(imd_force), imd_force
-
-
-@pytest.fixture
-def serialized_single_atom_simulation_path(single_atom_simulation, tmp_path):
-    """
-    Setup an XML serialized simulation for a single atom system as a temporary file.
-    """
-    serialized_simulation = serializer.serialize_simulation(
-        single_atom_simulation, save_state=True
-    )
-    xml_path = tmp_path / "system.xml"
-    with open(str(xml_path), "w") as outfile:
-        outfile.write(serialized_simulation)
-    return xml_path
-
-
-@pytest.fixture
-def single_atom_simulation_xml(single_atom_simulation):
-    """
-    Generate an XML serialized simulation from the single atom test simulation.
-    """
-    xml_string = serializer.serialize_simulation(
-        single_atom_simulation, save_state=True
-    )
-    return xml_string
 
 
 def assert_single_atom_simulation_topology(frame):

--- a/python-libraries/nanover-omni/tests/test_all.py
+++ b/python-libraries/nanover-omni/tests/test_all.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import numpy
 import pytest
 
-from nanover.omni.omni import Simulation, CLEAR_PREFIXES
+from nanover.omni.omni import CLEAR_PREFIXES
 from nanover.testing import assert_equal_soon, assert_in_soon, assert_not_in_soon
 from nanover.utilities.change_buffers import DictionaryChange
 from test_openmm import make_example_openmm
@@ -21,12 +21,6 @@ SIMULATION_FACTORIES_ALL = SIMULATION_FACTORIES_IMD + [make_example_playback]
 
 
 TIMING_TOLERANCE = 0.05
-
-
-def make_sim_from_fixture(request, fixture_name):
-    simulation: Simulation = request.getfixturevalue(fixture_name)
-    simulation.name = fixture_name
-    return simulation
 
 
 def make_imd_sims():

--- a/python-libraries/nanover-omni/tests/test_all.py
+++ b/python-libraries/nanover-omni/tests/test_all.py
@@ -1,126 +1,114 @@
 import time
-from contextlib import contextmanager
 from unittest.mock import patch
 
 import numpy
 import pytest
 
-from nanover.app import NanoverImdClient
-from nanover.omni.omni import Simulation, OmniRunner, CLEAR_PREFIXES
+from nanover.omni.omni import Simulation, CLEAR_PREFIXES
 from nanover.testing import assert_equal_soon, assert_in_soon, assert_not_in_soon
 from nanover.utilities.change_buffers import DictionaryChange
-from test_openmm import example_openmm
-from test_ase import example_ase, example_dynamics
-from test_playback import example_playback
-from openmm_simulation_utils import single_atom_simulation
-from common import app_server
+from test_openmm import make_example_openmm
+from test_ase import make_example_ase
+from test_playback import make_example_playback
+from common import make_runner, make_connected_client_from_runner, make_app_server
 
-SIMULATION_FIXTURES = (
-    "example_openmm",
-    "example_playback",
-    "example_ase",
-)
-
-SIMULATION_FIXTURES_WITHOUT_PLAYBACK = [
-    "example_openmm",
-    "example_ase",
+SIMULATION_FACTORIES_IMD = [
+    make_example_openmm,
+    make_example_ase,
 ]
+
+SIMULATION_FACTORIES_ALL = SIMULATION_FACTORIES_IMD + [make_example_playback]
 
 
 TIMING_TOLERANCE = 0.05
 
 
+def make_sim_from_fixture(request, fixture_name):
+    simulation: Simulation = request.getfixturevalue(fixture_name)
+    simulation.name = fixture_name
+    return simulation
+
+
+def make_imd_sims():
+    return [sim_factory() for sim_factory in SIMULATION_FACTORIES_IMD]
+
+
+def make_all_sims():
+    return [sim_factory() for sim_factory in SIMULATION_FACTORIES_ALL]
+
+
 @pytest.fixture
-def multi_sim_runner(request):
-    with OmniRunner.with_basic_server(port=0) as runner:
-        for sim_fixture in SIMULATION_FIXTURES:
-            simulation = request.getfixturevalue(sim_fixture)
-            simulation.name = sim_fixture
-            runner.add_simulation(simulation)
+def runner_with_all_sims():
+    with make_runner(*make_all_sims()) as runner:
         yield runner
 
 
-@contextmanager
-def make_client_connected_to_runner(runner):
-    with NanoverImdClient.connect_to_single_server(
-        port=runner.app_server.port
-    ) as client:
-        yield client
-
-
 @pytest.fixture
-def multi_sim_client_runner(multi_sim_runner):
-    with make_client_connected_to_runner(multi_sim_runner) as client:
-        yield client, multi_sim_runner
+def runner_with_imd_sims():
+    with make_runner(*make_imd_sims()) as runner:
+        yield runner
 
 
-@pytest.fixture
-def multi_sim_client_runner_without_playback(request):
-    with OmniRunner.with_basic_server(port=0) as runner:
-        for sim_fixture in SIMULATION_FIXTURES_WITHOUT_PLAYBACK:
-            simulation = request.getfixturevalue(sim_fixture)
-            simulation.name = sim_fixture
-            runner.add_simulation(simulation)
-        with NanoverImdClient.connect_to_single_server(
-            port=runner.app_server.port
-        ) as client:
-            yield client, runner
-
-
-@pytest.mark.parametrize("sim_fixture", SIMULATION_FIXTURES)
-def test_reset(sim_fixture, app_server, request):
-    sim: Simulation = request.getfixturevalue(sim_fixture)
-    sim.reset(app_server)
-
-
-@pytest.mark.parametrize("sim_fixture", SIMULATION_FIXTURES)
-def test_load(sim_fixture, request):
-    sim: Simulation = request.getfixturevalue(sim_fixture)
+@pytest.mark.parametrize("sim_factory", SIMULATION_FACTORIES_ALL)
+def test_load(sim_factory):
+    sim = sim_factory()
     sim.load()
+
+
+@pytest.mark.parametrize("sim_factory", SIMULATION_FACTORIES_ALL)
+def test_reset(sim_factory):
+    sim = sim_factory()
+
+    with make_app_server() as app_server:
+        sim.load()
+        sim.reset(app_server)
 
 
 # TODO: not true for playback because stepping might step through state changes...
-@pytest.mark.parametrize("sim_fixture", SIMULATION_FIXTURES_WITHOUT_PLAYBACK)
-def test_step_gives_exactly_one_frame(sim_fixture, request, app_server):
+@pytest.mark.parametrize("sim_factory", SIMULATION_FACTORIES_IMD)
+def test_step_gives_exactly_one_frame(sim_factory):
     """
     Test that stepping sends exactly one frame.
     """
-    sim: Simulation = request.getfixturevalue(sim_fixture)
-    sim.load()
-    sim.reset(app_server)
-    sim.advance_by_one_step()
+    with make_app_server() as app_server:
+        sim = sim_factory()
+        sim.load()
+        sim.reset(app_server)
+        sim.advance_by_one_step()
 
-    with patch.object(
-        app_server.frame_publisher, "send_frame", autospec=True
-    ) as send_frame:
-        for i in range(1, 20):
-            sim.advance_by_one_step()
-            assert send_frame.call_count == i
+        with patch.object(
+            app_server.frame_publisher, "send_frame", autospec=True
+        ) as send_frame:
+            for i in range(1, 20):
+                sim.advance_by_one_step()
+                assert send_frame.call_count == i
 
 
-def test_list_simulations(multi_sim_runner):
+def test_list_simulations(runner_with_all_sims):
     """
     Test runner lists exactly the expected simulations.
     """
-    names = multi_sim_runner.list()["simulations"]
-    assert sorted(names) == sorted(SIMULATION_FIXTURES)
+    names = runner_with_all_sims.list()["simulations"]
+    assert sorted(names) == sorted(sim.name for sim in make_all_sims())
 
 
-def test_next_simulation_increments_counter(multi_sim_client_runner_without_playback):
+def test_next_simulation_increments_counter(runner_with_imd_sims):
     """
     Test each next command increments the simulation counter to the correct value.
     """
-    client, runner = multi_sim_client_runner_without_playback
-    client.subscribe_to_frames()
+    with make_connected_client_from_runner(runner_with_imd_sims) as client:
+        client.subscribe_to_frames()
 
-    for i in range(5):
-        client.run_next()
-        client.wait_until_first_frame()
-        assert_equal_soon(lambda: client.current_frame.simulation_counter, lambda: i)
+        for i in range(5):
+            client.run_next()
+            client.wait_until_first_frame()
+            assert_equal_soon(
+                lambda: client.current_frame.simulation_counter, lambda: i
+            )
 
 
 @pytest.mark.parametrize("fps", (5, 10, 30))
-def test_play_step_interval(multi_sim_client_runner_without_playback, fps):
+def test_play_step_interval(runner_with_imd_sims, fps):
     """
     Test that the play step interval is respected and the sent frame frequency matches the requested interval.
     We only guarantee that the interval is close on average.
@@ -129,19 +117,19 @@ def test_play_step_interval(multi_sim_client_runner_without_playback, fps):
     test_frames = 30
 
     play_step_interval = 1 / fps
-    client, runner = multi_sim_client_runner_without_playback
 
-    client.subscribe_to_all_frames()
-    runner.next()
-    runner.runner.play_step_interval = play_step_interval
+    with make_connected_client_from_runner(runner_with_imd_sims) as client:
+        client.subscribe_to_all_frames()
+        runner_with_imd_sims.next()
+        runner_with_imd_sims.runner.play_step_interval = play_step_interval
 
-    while len(client.frames) < test_frames:
-        time.sleep(0.1)
-    runner.pause()
+        while len(client.frames) < test_frames:
+            time.sleep(0.1)
+        runner_with_imd_sims.pause()
 
-    # first frame (topology) isn't subject to intervals
-    timestamps = [frame.server_timestamp for frame in client.frames[1:]]
-    deltas = numpy.diff(timestamps)
+        # first frame (topology) isn't subject to intervals
+        timestamps = [frame.server_timestamp for frame in client.frames[1:]]
+        deltas = numpy.diff(timestamps)
 
     # The interval is not very accurate. We only check that the observed
     # interval is close on average.
@@ -150,7 +138,7 @@ def test_play_step_interval(multi_sim_client_runner_without_playback, fps):
     )
 
 
-def test_simulation_switch_clears_state(multi_sim_runner):
+def test_simulation_switch_clears_state(runner_with_all_sims):
     """
     Test that state keys with certain prefixes are no longer present in the state after switching simulation.
     """
@@ -159,11 +147,11 @@ def test_simulation_switch_clears_state(multi_sim_runner):
     updates = {prefix + key: {} for prefix in CLEAR_PREFIXES}
     locks = {key: 10 for key in updates}
 
-    with make_client_connected_to_runner(multi_sim_runner) as client:
+    with make_connected_client_from_runner(runner_with_all_sims) as client:
         client.attempt_update_multiplayer_state(DictionaryChange(updates=updates))
         client.attempt_update_multiplayer_locks(locks)
 
-    with make_client_connected_to_runner(multi_sim_runner) as client:
+    with make_connected_client_from_runner(runner_with_all_sims) as client:
         client.subscribe_multiplayer()
 
         for key in updates:
@@ -174,4 +162,20 @@ def test_simulation_switch_clears_state(multi_sim_runner):
         for key in updates:
             assert_not_in_soon(
                 lambda: key, lambda: client._multiplayer_client.copy_state()
+            )
+
+
+@pytest.mark.parametrize("sim_factory", SIMULATION_FACTORIES_IMD)
+def test_first_frame_topology(sim_factory):
+    """
+    Test that the first frame contains topology and position information.
+    """
+    with make_runner(sim_factory()) as runner:
+        with make_connected_client_from_runner(runner) as client:
+            client.subscribe_to_frames()
+            runner.load(0)
+            client.wait_until_first_frame()
+            assert (
+                len(client.first_frame.particle_positions) > 0
+                and len(client.first_frame.particle_elements) > 0
             )

--- a/python-libraries/nanover-omni/tests/test_all.py
+++ b/python-libraries/nanover-omni/tests/test_all.py
@@ -169,6 +169,9 @@ def test_first_frame_topology(sim_factory):
             client.subscribe_to_frames()
             runner.load(0)
             client.wait_until_first_frame()
+            # Currently the initial frame is the only frame containing the element
+            # information, so this is equivalent to testing the frame in which the
+            # topology is sent (where relevant).
             assert (
                 len(client.first_frame.particle_positions) > 0
                 and len(client.first_frame.particle_elements) > 0

--- a/python-libraries/nanover-omni/tests/test_openmm.py
+++ b/python-libraries/nanover-omni/tests/test_openmm.py
@@ -112,9 +112,8 @@ def basic_system_app_and_simulation_with_constant_force_old():
         sim.load()
         sim.reset(app_server)
 
-        # Add a constant force interaction with the force positioned far
-        # from the origin and a harmonic force sqrt(2) from the origin,
-        # acting on different atoms
+        # Add a constant force interaction with the force positioned at
+        # 1 nm along the positive x axis
         interaction_1 = ParticleInteraction(
             interaction_type="constant",
             position=(0.0, 0.0, 1.0),

--- a/python-libraries/nanover-omni/tests/test_openmm.py
+++ b/python-libraries/nanover-omni/tests/test_openmm.py
@@ -37,7 +37,7 @@ def example_openmm():
 
 
 def make_example_openmm():
-    return OpenMMSimulation.from_simulation(build_single_atom_simulation())
+    return OpenMMSimulation.from_simulation(build_basic_simulation())
 
 
 @pytest.fixture
@@ -198,12 +198,12 @@ def test_work_done_server(single_atom_app_and_simulation_with_constant_force):
     assert sim.work_done == pytest.approx(20.0, abs=0.05)
 
 
-def test_work_done_frame(single_atom_app_and_simulation_with_constant_force):
+def test_work_done_frame(basic_system_app_and_simulation_with_complex_interactions):
     """
-    Test that the calculated user work done on a single atom system that appears
-    in the frame is equal to the user work done as calculated in the OpenMMSimulation.
+    Test that the calculated user work done on a system that appears in the frame is equal
+    to the user work done as calculated in the OpenMMSimulation.
     """
-    app, sim = single_atom_app_and_simulation_with_constant_force
+    app, sim = basic_system_app_and_simulation_with_complex_interactions
 
     for _ in range(11):
         sim.advance_to_next_report()

--- a/python-libraries/nanover-omni/tests/test_openmm.py
+++ b/python-libraries/nanover-omni/tests/test_openmm.py
@@ -338,13 +338,15 @@ def test_reset_gives_equal_frames():
     assert all(np.all(prev_data[key] - next_data[key]) == 0 for key in prev_data)
 
 
-def test_force_manager_masses(example_openmm):
+def test_force_manager_masses(basic_system_app_and_simulation):
     """
     Test that the force manager has the correct masses for the simulated system.
     """
+    _, sim = basic_system_app_and_simulation
+
     for _ in range(10):
-        example_openmm.advance_by_one_step()
-        assert example_openmm.imd_force_manager.masses == pytest.approx([40])
+        sim.advance_by_one_step()
+        assert sim.imd_force_manager.masses == pytest.approx([12, 1, 1, 1, 12, 1, 1, 1])
 
 
 # TODO: could generalise for both OMM and ASE

--- a/python-libraries/nanover-omni/tests/test_openmm.py
+++ b/python-libraries/nanover-omni/tests/test_openmm.py
@@ -490,29 +490,6 @@ def test_sparse_user_forces_elements(
         )
 
 
-def test_velocities_and_forces(basic_system_app_and_simulation_with_constant_force_old):
-    """
-    Test the particle velocities and particle forces that can be optionally included
-    when running OpenMM simulations. Assert that these arrays exist, have the same
-    length as the particle positions array and are non-zero.
-    """
-    app, sim = basic_system_app_and_simulation_with_constant_force_old
-
-    sim.include_forces = True
-    sim.include_velocities = True
-
-    sim.advance_by_one_step()
-    frame = connect_and_retrieve_first_frame_from_app_server(app)
-
-    # TODO: which particle forces field to use?
-    assert frame.particle_velocities
-    assert frame.particle_forces_system
-    assert len(frame.particle_velocities) == len(frame.particle_positions)
-    assert len(frame.particle_forces_system) == len(frame.particle_positions)
-    assert np.all(frame.particle_velocities) != 0.0
-    assert np.all(frame.particle_forces_system) != 0.0
-
-
 def test_velocities_and_forces_single_atom():
     """
     Numerically test the optionally included velocities and forces being passed

--- a/python-libraries/nanover-omni/tests/test_openmm.py
+++ b/python-libraries/nanover-omni/tests/test_openmm.py
@@ -442,7 +442,6 @@ def test_velocities_and_forces(basic_system_app_and_simulation_with_constant_for
     sim.advance_by_one_step()
     frame = connect_and_retrieve_first_frame_from_app_server(app)
 
-    # TODO: which particle forces field to use?
     assert frame.particle_velocities
     assert frame.particle_forces_system
     assert len(frame.particle_velocities) == len(frame.particle_positions)

--- a/python-libraries/nanover-omni/tests/test_openmm.py
+++ b/python-libraries/nanover-omni/tests/test_openmm.py
@@ -380,27 +380,27 @@ def test_sparse_user_forces(basic_system_app_and_simulation_with_constant_force)
     assert np.all(frame.user_forces_sparse) != 0.0
 
 
-def test_apply_interactions(basic_system_app_and_simulation_with_constant_force):
+def test_apply_interactions(basic_system_app_and_simulation_with_complex_interactions):
     """
     Interactions are applied and the computed forces are passed to the imd
     force object.
     """
-    app, sim = basic_system_app_and_simulation_with_constant_force
+    app, sim = basic_system_app_and_simulation_with_complex_interactions
     sim.advance_by_one_step()
 
     assert_imd_force_affected_particles(
         sim.imd_force_manager.imd_force,
-        expected_affected_indices={0, 6},
+        expected_affected_indices={0, 1, 4, 5},
     )
 
 
 def test_remove_interaction_partial(
-    basic_system_app_and_simulation_with_constant_force,
+    basic_system_app_and_simulation_with_complex_interactions,
 ):
     """
     When an interaction is removed, the corresponding forces are reset.
     """
-    app, sim = basic_system_app_and_simulation_with_constant_force
+    app, sim = basic_system_app_and_simulation_with_complex_interactions
 
     sim.advance_by_one_step()
     app.imd.remove_interaction("interaction.0")
@@ -408,17 +408,17 @@ def test_remove_interaction_partial(
 
     assert_imd_force_affected_particles(
         sim.imd_force_manager.imd_force,
-        expected_affected_indices={6},
+        expected_affected_indices={4, 5},
     )
 
 
 def test_remove_interaction_complete(
-    basic_system_app_and_simulation_with_constant_force,
+    basic_system_app_and_simulation_with_complex_interactions,
 ):
     """
     When all interactions are removed, all the corresponding forces are reset.
     """
-    app, sim = basic_system_app_and_simulation_with_constant_force
+    app, sim = basic_system_app_and_simulation_with_complex_interactions
 
     sim.advance_by_one_step()
     app.imd.remove_interaction("interaction.0")

--- a/python-libraries/nanover-omni/tests/test_openmm.py
+++ b/python-libraries/nanover-omni/tests/test_openmm.py
@@ -20,7 +20,8 @@ from nanover.trajectory import FrameData
 from common import (
     make_app_server,
     connect_and_retrieve_first_frame_from_app_server,
-    make_loaded_sim, make_loaded_sim_with_interactions,
+    make_loaded_sim,
+    make_loaded_sim_with_interactions,
 )
 
 from openmm_simulation_utils import (


### PR DESCRIPTION
Reduce unwieldy fixtures and prepare to remove non-omni openmm.

Need to replicate from non-omni openmm tests:

- [x] test_force_manager_masses
- [x] test_report_frame_forces
- [x] test_sparse_user_forces
- [x] test_apply_interactions
- [x] test_remove_interaction_partial
- [x] test_remove_interaction_complete
- [x] test_sparse_user_forces_elements
- [x] test_velocities_and_forces
- [x] test_velocities_and_forces_single_atom
