### PR TITLE
Reset work and iMD forces when reseting simulations

### DIFF
--- a/python-libraries/nanover-server/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-server/src/nanover/omni/ase.py
@@ -128,6 +128,12 @@ class ASESimulation:
 
         self.app_server = app_server
 
+        # reset imd and work
+        self.work_done = 0.0
+        self._work_done_intermediate = 0.0
+        self._prev_imd_forces = None
+        self._prev_imd_indices = None
+
         # reset atoms to initial state
         self.atoms.set_positions(self.checkpoint.positions)
         self.atoms.set_velocities(self.checkpoint.velocities)

--- a/python-libraries/nanover-server/src/nanover/omni/openmm.py
+++ b/python-libraries/nanover-server/src/nanover/omni/openmm.py
@@ -120,6 +120,12 @@ class OpenMMSimulation:
 
         self._dof = compute_dof(self.simulation.system)
 
+        # reset imd and work
+        self.work_done = 0.0
+        self._work_done_intermediate = 0.0
+        self._prev_imd_forces = None
+        self._prev_imd_indices = None
+
         # reload initial state and cleanup forces
         self.simulation.context.reinitialize()
         self.simulation.context.loadCheckpoint(self.checkpoint)

--- a/python-libraries/nanover-server/src/nanover/openmm/imd.py
+++ b/python-libraries/nanover-server/src/nanover/openmm/imd.py
@@ -38,6 +38,10 @@ class ImdForceManager:
         self._previous_force_index: Set[int] = set()
         self._total_user_energy = 0.0
 
+        # clear any residual forces in external force
+        for particle in range(self.imd_force.getNumParticles()):
+            self.imd_force.setParticleParameters(particle, particle, (0, 0, 0))
+
     def update_interactions(self, simulation: Simulation, positions: np.ndarray):
         if self.masses is None:
             self._update_masses(simulation.system)

--- a/python-libraries/nanover-server/tests/test_omni/test_ase.py
+++ b/python-libraries/nanover-server/tests/test_omni/test_ase.py
@@ -390,7 +390,7 @@ def test_work_done_server_reset(example_ase_app_sim_constant_force_interaction):
         # Time accumulates across resets
         expected_dynamics_time = (i + 1) * test_time
 
-        actual_dynamics_time = sim.dynamics.get_time() * ASE_TIME_UNIT_TO_PS()
+        actual_dynamics_time = sim.dynamics.get_time() * ASE_TIME_UNIT_TO_PS
 
         # Check that 1.0025 ps have passed (and hence that force has been applied for 1 ps)
         assert actual_dynamics_time == pytest.approx(expected_dynamics_time, abs=10e-12)

--- a/python-libraries/nanover-server/tests/test_omni/test_ase.py
+++ b/python-libraries/nanover-server/tests/test_omni/test_ase.py
@@ -10,7 +10,11 @@ from nanover.app import NanoverImdClient
 from nanover.omni.ase import ASESimulation
 from nanover.ase.converter import ASE_TIME_UNIT_TO_PS, ANG_TO_NM, EV_TO_KJMOL
 
-from common import make_app_server, make_loaded_sim
+from common import (
+    make_app_server,
+    make_loaded_sim,
+    connect_and_retrieve_first_frame_from_app_server,
+)
 
 
 @pytest.fixture
@@ -338,10 +342,29 @@ def test_imd_force_unit_conversion(example_ase_app_sim_constant_force_interactio
             )
 
 
-def test_work_done_server(example_ase_app_sim_constant_force_interaction):
+def test_work_done_frame(example_ase_app_sim_constant_force_interaction):
+    """
+    Test that the calculated user work done on a single atom system that appears
+    in the frame is equal to the user work done as calculated in the ASESimulation,
+    even after resets.
+    """
+    app, sim = example_ase_app_sim_constant_force_interaction
+
+    for _ in range(5):
+        sim.reset(app)
+
+        for _ in range(11):
+            sim.advance_to_next_report()
+
+        frame = connect_and_retrieve_first_frame_from_app_server(app)
+        assert frame.user_work_done == sim.work_done
+
+
+def test_work_done_server_reset(example_ase_app_sim_constant_force_interaction):
     """
     Test that the calculated user work done on a single atom system gives the
-    expected numerical result within the code.
+    expected numerical result within the code, and doesn't accumulate across
+    resets.
     """
 
     # For a simulation with a frame interval of 5 simulation steps and a simulation
@@ -353,32 +376,29 @@ def test_work_done_server(example_ase_app_sim_constant_force_interaction):
     app, sim = example_ase_app_sim_constant_force_interaction
 
     # Add step to account for zeroth (topology) frame where force is not applied
-    for _ in range(401):
-        sim.advance_to_next_report()
+    test_steps = 400 + 1
 
-    # Check that 1.0025 ps have passed (and hence that force has been applied for 1 ps)
-    assert sim.dynamics.get_time() * ASE_TIME_UNIT_TO_PS == pytest.approx(
-        1.0025, abs=10e-12
-    )
-    assert sim.work_done == pytest.approx(20.0, abs=1e-6)
+    # Passing 1.0025 ps will apply force for 1 ps
+    test_time = test_steps * 0.0025
 
+    expected_work = 20.0
 
-def test_work_done_frame(example_ase_app_sim_constant_force_interaction):
-    """
-    Test that the calculated user work done on a single atom system that appears
-    in the frame is equal to the user work done as calculated in the ASESimulation.
-    """
-    app, sim = example_ase_app_sim_constant_force_interaction
+    for i in range(3):
+        for _ in range(test_steps):
+            sim.advance_to_next_report()
 
-    for _ in range(11):
-        sim.advance_to_next_report()
+        # Time accumulates across resets
+        expected_dynamics_time = (i + 1) * test_time
 
-    with NanoverImdClient.connect_to_single_server(
-        port=app.port, address="localhost"
-    ) as client:
-        client.subscribe_to_frames()
-        client.wait_until_first_frame()
-        assert client.current_frame.user_work_done == sim.work_done
+        actual_dynamics_time = sim.dynamics.get_time() * ASE_TIME_UNIT_TO_PS()
+
+        # Check that 1.0025 ps have passed (and hence that force has been applied for 1 ps)
+        assert actual_dynamics_time == pytest.approx(expected_dynamics_time, abs=10e-12)
+        assert sim.work_done == pytest.approx(expected_work, abs=1e-6)
+
+        # Reset simulation and check work done is now zero
+        sim.reset(app)
+        assert sim.work_done == 0
 
 
 def test_instantaneous_temperature(example_ase_app_sim_constant_force_interaction):
@@ -394,11 +414,5 @@ def test_instantaneous_temperature(example_ase_app_sim_constant_force_interactio
     # Calculate temperature using method in ASE Atoms class
     ase_temp = sim.atoms.get_temperature()
 
-    with NanoverImdClient.connect_to_single_server(
-        port=app.port, address="localhost"
-    ) as client:
-        client.subscribe_to_frames()
-        client.wait_until_first_frame()
-        assert client.current_frame.system_temperature == pytest.approx(
-            ase_temp, abs=1e-12
-        )
+    frame = connect_and_retrieve_first_frame_from_app_server(app)
+    assert frame.system_temperature == pytest.approx(ase_temp, abs=1e-12)

--- a/python-libraries/nanover-server/tests/test_omni/test_openmm.py
+++ b/python-libraries/nanover-server/tests/test_omni/test_openmm.py
@@ -178,7 +178,7 @@ def test_step_interval(example_openmm):
 def test_work_done_server(single_atom_app_and_simulation_with_constant_force):
     """
     Test that the calculated user work done on a single atom system gives the
-    expected numerical result within the code.
+    expected numerical result within the code, even across resets.
     """
 
     # For a simulation with a frame interval of 5 simulation steps and a simulation
@@ -189,13 +189,20 @@ def test_work_done_server(single_atom_app_and_simulation_with_constant_force):
 
     app, sim = single_atom_app_and_simulation_with_constant_force
 
-    # Add step to account for zeroth (topology) frame where force is not applied
-    for _ in range(101):
-        sim.advance_to_next_report()
+    for _ in range(3):
+        # Add step to account for zeroth (topology) frame where force is not applied
+        for _ in range(101):
+            sim.advance_to_next_report()
 
-    # Check that 1.01 ps have passed (and hence that force has been applied for 1 ps)
-    assert sim.simulation.context.getTime()._value == pytest.approx(1.01, abs=10e-12)
-    assert sim.work_done == pytest.approx(20.0, abs=0.05)
+        # Check that 1.01 ps have passed (and hence that force has been applied for 1 ps)
+        assert sim.simulation.context.getTime()._value == pytest.approx(
+            1.01, abs=10e-12
+        )
+        assert sim.work_done == pytest.approx(20.0, abs=0.05)
+
+        # Reset simulation and check work done is now zero
+        sim.reset(app)
+        assert sim.work_done == 0
 
 
 def test_work_done_frame(basic_system_app_and_simulation_with_complex_interactions):
@@ -205,15 +212,14 @@ def test_work_done_frame(basic_system_app_and_simulation_with_complex_interactio
     """
     app, sim = basic_system_app_and_simulation_with_complex_interactions
 
-    for _ in range(11):
-        sim.advance_to_next_report()
+    for _ in range(3):
+        sim.reset(app)
 
-    with NanoverImdClient.connect_to_single_server(
-        port=app.port, address="localhost"
-    ) as client:
-        client.subscribe_to_frames()
-        client.wait_until_first_frame()
-        assert client.current_frame.user_work_done == sim.work_done
+        for _ in range(11):
+            sim.advance_to_next_report()
+
+        frame = connect_and_retrieve_first_frame_from_app_server(app)
+        assert frame.user_work_done == sim.work_done
 
 
 def test_save_state_basic_system(basic_system_app_and_simulation_with_constant_force):
@@ -269,14 +275,8 @@ def test_instantaneous_temperature_no_interaction(basic_system_app_and_simulatio
 
         state_data_temperature = float(state_data_output.getvalue().split(",")[-1])
 
-    with NanoverImdClient.connect_to_single_server(
-        port=app.port, address="localhost"
-    ) as client:
-        client.subscribe_to_frames()
-        client.wait_until_first_frame()
-        assert client.current_frame.system_temperature == pytest.approx(
-            state_data_temperature, abs=1e-12
-        )
+    frame = connect_and_retrieve_first_frame_from_app_server(app)
+    assert frame.system_temperature == pytest.approx(state_data_temperature, abs=1e-12)
 
 
 def test_instantaneous_temperature_imd_interaction(
@@ -303,16 +303,11 @@ def test_instantaneous_temperature_imd_interaction(
 
         state_data_temperature = float(state_data_output.getvalue().split(",")[-1])
 
-    with NanoverImdClient.connect_to_single_server(
-        port=app.port, address="localhost"
-    ) as client:
-        client.subscribe_to_frames()
-        client.wait_until_first_frame()
-        frame_temperature = client.current_frame.system_temperature
-        # Check that the temperature during the iMD interaction is within
-        # 1% of the temperature calculated by the StateDataReporter (including
-        # the effect of the iMD interaction on the temperature)
-        assert frame_temperature == pytest.approx(state_data_temperature, rel=1.0e-2)
+    # Check that the temperature during the iMD interaction is within
+    # 1% of the temperature calculated by the StateDataReporter (including
+    # the effect of the iMD interaction on the temperature)
+    frame = connect_and_retrieve_first_frame_from_app_server(app)
+    assert frame.system_temperature == pytest.approx(state_data_temperature, rel=1.0e-2)
 
 
 def test_reset_gives_equal_frames():


### PR DESCRIPTION
Closes https://github.com/IRL2/nanover-server-py/issues/373

Resets internal data for work done and imd forces when simulations are reset. Expands existing work tests to check that they still hold after multiple sequential runs after resets. Adds a fix to the ImdForceManager that clears out any residual forces in the OpenMM force between resets.