### PR TITLE
fix: ignore ctrl+c during shutdown

### DIFF
--- a/python-libraries/nanover-server/src/nanover/omni/cli.py
+++ b/python-libraries/nanover-server/src/nanover/omni/cli.py
@@ -3,6 +3,7 @@ Command line interface for nanover.omni.
 """
 
 import logging
+import signal
 import time
 import textwrap
 import argparse
@@ -167,6 +168,11 @@ def main():
                 app.run()
         else:
             runner.print_basic_info_and_wait()
+
+        def handler(signum, frame):
+            print("(ignoring additional keyboard interrupt while closing)")
+
+        signal.signal(signal.SIGINT, handler)
 
 
 if __name__ == "__main__":

--- a/python-libraries/nanover-server/src/nanover/omni/cli.py
+++ b/python-libraries/nanover-server/src/nanover/omni/cli.py
@@ -3,7 +3,6 @@ Command line interface for nanover.omni.
 """
 
 import logging
-import signal
 import time
 import textwrap
 import argparse
@@ -15,8 +14,7 @@ from nanover.omni import OmniRunner
 from nanover.omni.openmm import OpenMMSimulation
 from nanover.omni.playback import PlaybackSimulation
 from nanover.omni.record import record_from_server
-from nanover.utilities.cli import suppress_keyboard_interrupt, suppress_keyboard_interrupt_as_event, \
-    suppress_keyboard_interrupt_as_cancellation
+from nanover.utilities.cli import suppress_keyboard_interrupt_as_cancellation
 
 
 def handle_user_arguments(args=None) -> argparse.Namespace:
@@ -171,7 +169,7 @@ def main():
                     app.run()
             else:
                 runner.print_basic_info()
-                cancellation.wait_cancellation(interval=.5)
+                cancellation.wait_cancellation(interval=0.5)
                 print("Closing due to KeyboardInterrupt.")
 
 

--- a/python-libraries/nanover-server/src/nanover/omni/omni.py
+++ b/python-libraries/nanover-server/src/nanover/omni/omni.py
@@ -89,9 +89,9 @@ class OmniRunner:
         self.app_server.close()
         self._cancel_run()
 
-    def print_basic_info_and_wait(self):
+    def print_basic_info(self):
         """
-        Print out basic runner info to the terminal and await keyboard interrupt.
+        Print out basic runner info to the terminal.
         """
         print(
             f'Serving "{self.app_server.name}" on port {self.app_server.port}, '
@@ -103,12 +103,6 @@ class OmniRunner:
             for index, simulation in enumerate(self.simulations)
         )
         print(f"Available simulations:\n{list}")
-
-        try:
-            while True:
-                time.sleep(1)
-        except KeyboardInterrupt:
-            print("Closing due to keyboard interrupt.")
 
     @property
     def app_server(self):

--- a/python-libraries/nanover-server/src/nanover/omni/omni.py
+++ b/python-libraries/nanover-server/src/nanover/omni/omni.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from concurrent.futures import ThreadPoolExecutor, Future
 from contextlib import suppress
 from queue import Queue, Empty

--- a/python-libraries/nanover-server/src/nanover/omni/recorder_cli.py
+++ b/python-libraries/nanover-server/src/nanover/omni/recorder_cli.py
@@ -101,7 +101,9 @@ def main():
             executor, channel = record_from_server(address, traj, state)
 
             try:
-                print(f"Recording from server to {traj} and {state}. Press Ctrl-C to stop.")
+                print(
+                    f"Recording from server to {traj} and {state}. Press Ctrl-C to stop."
+                )
                 cancellation.wait_cancellation(interval=0.01)
             finally:
                 channel.close()

--- a/python-libraries/nanover-server/src/nanover/utilities/cli.py
+++ b/python-libraries/nanover-server/src/nanover/utilities/cli.py
@@ -1,0 +1,44 @@
+import time
+from signal import signal, SIGINT
+from contextlib import contextmanager
+
+
+@contextmanager
+def suppress_keyboard_interrupt_as_cancellation():
+    """
+    Context manager that suppresses KeyboardInterrupt and instead yields a cancellation token that can be polled to
+    check if a keyboard interrupt has occurred during the lifetime of the context.
+    """
+    token = CancellationToken()
+
+    prev_handler = signal(SIGINT, lambda _, __: token.cancel())
+    try:
+        yield token
+    finally:
+        signal(SIGINT, prev_handler)
+
+
+class CancellationToken:
+    _cancelled = False
+
+    @property
+    def is_cancelled(self):
+        """
+        Has this token been cancelled?
+        """
+        return self._cancelled
+
+    def cancel(self):
+        """
+        Cancel this token.
+        """
+        self._cancelled = True
+
+    def wait_cancellation(self, interval=0.1):
+        """
+        Sleep until this token is cancelled.
+
+        :param interval: the interval in seconds between waking up to check cancellation.
+        """
+        while not self._cancelled:
+            time.sleep(interval)


### PR DESCRIPTION
fixes https://github.com/IRL2/nanover-server-py/issues/377 and https://github.com/IRL2/nanover-server-py/issues/379

Ignore keyboard interrupt while shutting down the server in the CLI. On windows this can interrupt threading which leaves the terminal in a hung state.