### PR TITLE
Catch ObjectFrozenError in UpdateState and return failure

### DIFF
--- a/python-libraries/nanover-server/src/nanover/state/state_service.py
+++ b/python-libraries/nanover-server/src/nanover/state/state_service.py
@@ -18,6 +18,7 @@ from nanover.utilities.protobuf_utilities import (
 from nanover.utilities.change_buffers import (
     DictionaryChange,
     DictionaryChangeBuffer,
+    ObjectFrozenError,
 )
 from nanover.protocol.state import (
     StateServicer,
@@ -136,7 +137,7 @@ class StateService(StateServicer):
         change = state_update_to_dictionary_change(request.update)
         try:
             self.update_state(request.access_token, change)
-        except ResourceLockedError:
+        except (ResourceLockedError, ObjectFrozenError):
             success = False
         return UpdateStateResponse(success=success)
 


### PR DESCRIPTION
Fixes https://github.com/IRL2/nanover-server-py/issues/393