### PR TITLE
Fix universes from recording function

### DIFF
--- a/python-libraries/nanover-server/src/nanover/mdanalysis/universe.py
+++ b/python-libraries/nanover-server/src/nanover/mdanalysis/universe.py
@@ -102,7 +102,9 @@ def universes_from_recording(*, traj: PathLike[str]):
         first_positions_frame = next(
             frame
             for (elapsed, frame, state) in session
-            if frame.particle_count > 0 and PARTICLE_POSITIONS in frame.arrays
+            if PARTICLE_POSITIONS in frame
+            and PARTICLE_COUNT in frame
+            and frame.particle_count > 0
         )
         universe = frame_data_to_mdanalysis(first_positions_frame)
         # integrate time elapsed into frames


### PR DESCRIPTION
I don't know why, but there can be strange resets in recordings where particle positions are present initially but topology information isn't. So we need to skip initial frames until both are present for this conversion.