### PR TITLE
`particle.colors` field (RGBA8)

### DIFF
--- a/python-libraries/nanover-server/src/nanover/trajectory/frame_dict.py
+++ b/python-libraries/nanover-server/src/nanover/trajectory/frame_dict.py
@@ -7,6 +7,7 @@ from nanover.utilities.packing import (
     pack_uint8,
     pack_uint32,
     pack_bond,
+    pack_color,
     force_int,
 )
 from . import keys
@@ -31,6 +32,7 @@ FRAME_PACKERS: dict[str, PackingPair] = {
     keys.PARTICLE_FORCES: pack_vec3,
     keys.PARTICLE_FORCES_SYSTEM: pack_vec3,
     keys.PARTICLE_ELEMENTS: pack_uint8,
+    keys.PARTICLE_COLORS: pack_color,
     keys.PARTICLE_RESIDUES: pack_uint32,
     keys.BOND_PAIRS: pack_bond,
     keys.BOND_ORDERS: pack_uint8,

--- a/python-libraries/nanover-server/src/nanover/trajectory/frame_wrapper.py
+++ b/python-libraries/nanover-server/src/nanover/trajectory/frame_wrapper.py
@@ -11,6 +11,7 @@ from . import keys
 EnumArray = npt.NDArray[np.uint8]
 IndexArray = npt.NDArray[np.uint32]
 FloatArray = npt.NDArray[np.float32]
+ColorArray = npt.NDArray[np.uint8]
 StringArray = list[str]
 
 
@@ -72,6 +73,7 @@ class FrameData:
     particle_forces: FloatArray = _shortcut(keys.PARTICLE_FORCES)
     particle_forces_system: FloatArray = _shortcut(keys.PARTICLE_FORCES_SYSTEM)
     particle_elements: EnumArray = _shortcut(keys.PARTICLE_ELEMENTS)
+    particle_colors: ColorArray = _shortcut(keys.PARTICLE_COLORS)
     particle_names: StringArray = _shortcut(keys.PARTICLE_NAMES)
     particle_residues: IndexArray = _shortcut(keys.PARTICLE_RESIDUES)
 

--- a/python-libraries/nanover-server/src/nanover/trajectory/keys.py
+++ b/python-libraries/nanover-server/src/nanover/trajectory/keys.py
@@ -19,6 +19,7 @@ PARTICLE_VELOCITIES = "particle.velocities"
 PARTICLE_FORCES = "particle.forces"
 PARTICLE_FORCES_SYSTEM = "particle.forces.system"
 PARTICLE_ELEMENTS = "particle.elements"
+PARTICLE_COLORS = "particle.colors"
 PARTICLE_NAMES = "particle.names"
 PARTICLE_RESIDUES = (
     "particle.residues"  # Index of the residue each particle belongs to.

--- a/python-libraries/nanover-server/src/nanover/utilities/packing.py
+++ b/python-libraries/nanover-server/src/nanover/utilities/packing.py
@@ -72,3 +72,4 @@ pack_uint8 = make_bytes_packer(np.uint8)
 
 pack_vec3 = make_bytes_packer(np.float32, shape=(-1, 3))
 pack_bond = make_bytes_packer(np.uint32, shape=(-1, 2))
+pack_color = make_bytes_packer(np.uint8, shape=(-1, 4))


### PR DESCRIPTION
```python
import numpy as np
from nanover.trajectory import FrameData

COLORS_FLOAT = np.array([
    [0., 1., 0., 1.],
    [1., 1., 0., 1.],
])
print(COLORS_FLOAT)

COLORS_UINT = (COLORS_FLOAT * 255).astype(np.uint8)
print(COLORS_UINT)

frame1 = FrameData()
frame1.particle_colors = COLORS_UINT 
frame2 = FrameData.unpack_from_dict(frame.pack_to_dict())

print(frame1.particle_colors)
print(frame2.particle_colors)
```